### PR TITLE
Create boot scene with dependency-injected bootstrapper

### DIFF
--- a/Assets/Scenes/Boot.unity
+++ b/Assets/Scenes/Boot.unity
@@ -1,0 +1,255 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 3
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 0
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 500
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 0
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &1000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1001}
+  - component: {fileID: 1002}
+  m_Layer: 0
+  m_Name: Bootstrapper
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 548e27ec5b0d00a40b95e58f32e707c2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  DemoSettingsPath: Assets/Data/demo.settings.json
+  ItemsPath: Assets/Data/goap/items.json
+--- !u!1 &2000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2001}
+  - component: {fileID: 2002}
+  - component: {fileID: 2003}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!20 &2002
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2000}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 2
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 0
+  m_HDR: 1
+  m_AllowMSAA: 0
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 0
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!81 &2003
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2000}
+  m_Enabled: 1

--- a/Assets/Scenes/Boot.unity.meta
+++ b/Assets/Scenes/Boot.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 27266f9e20796744b83c8590b7e81046
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Sim/World/GameServices.cs
+++ b/Assets/Scripts/Sim/World/GameServices.cs
@@ -1,0 +1,155 @@
+// Assets/Scripts/Sim/World/GameServices.cs
+// C# 8.0
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.UIElements;
+using Microsoft.Extensions.DependencyInjection;
+using Sim.Config;
+using Sim.Logging;
+
+namespace Sim.World
+{
+    public interface IWorldLogger
+    {
+        void Initialize();
+        void World(string message);
+    }
+
+    public sealed class WorldLogger : IWorldLogger
+    {
+        public void Initialize()
+        {
+            Log.InitLogs();
+        }
+
+        public void World(string message)
+        {
+            if (string.IsNullOrEmpty(message))
+                return;
+
+            Log.World(message);
+        }
+    }
+
+    public interface IContentValidationService
+    {
+        void ValidateAll();
+    }
+
+    public sealed class ContentValidationService : IContentValidationService
+    {
+        public void ValidateAll()
+        {
+            ContentValidator.ValidateAll();
+        }
+    }
+
+    public interface IPanelSettingsProvider
+    {
+        PanelSettings GetOrCreate();
+    }
+
+    public sealed class ResourcesPanelSettingsProvider : IPanelSettingsProvider
+    {
+        private PanelSettings _cached;
+
+        public PanelSettings GetOrCreate()
+        {
+            if (_cached != null)
+                return _cached;
+
+            _cached = Resources.Load<PanelSettings>("PanelSettings/DefaultPanelSettings");
+            if (_cached == null)
+            {
+                _cached = ScriptableObject.CreateInstance<PanelSettings>();
+            }
+
+            return _cached;
+        }
+    }
+
+    public interface IWorldLoader
+    {
+        Thing LoadDemoWorld(string demoSettingsPath);
+    }
+
+    public sealed class PantryWorldLoader : IWorldLoader
+    {
+        private readonly IWorldLogger _logger;
+
+        public PantryWorldLoader(IWorldLogger logger)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public Thing LoadDemoWorld(string demoSettingsPath)
+        {
+            if (string.IsNullOrWhiteSpace(demoSettingsPath))
+                throw new ArgumentException("Demo settings path is required.", nameof(demoSettingsPath));
+
+            _logger.World("LoadWorld() begin.");
+
+            var root = ConfigLoader.LoadJson<TempRoot>(demoSettingsPath);
+            if (root?.placements?.things == null)
+                throw new InvalidDataException("demo.settings.json missing placements.things");
+
+            WorldState.Things.Clear();
+
+            foreach (var td in root.placements.things)
+            {
+                if (td == null || string.IsNullOrEmpty(td.type))
+                    continue;
+
+                if (!string.Equals(td.type, "pantry", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                var id = td.id;
+                if (string.IsNullOrWhiteSpace(id))
+                    id = Guid.NewGuid().ToString("N");
+
+                var thing = new Thing(id, td.type, new Vector2Int(td.x, td.y), td.attributes);
+                var capacity = thing.GetIntAttr("inventory_capacity", 0);
+                if (capacity <= 0)
+                    throw new InvalidDataException("Pantry missing attributes.inventory_capacity in demo.settings.json");
+
+                thing.Inventory = new Inventory(capacity);
+                WorldState.Things[thing.Id] = thing;
+            }
+
+            if (WorldState.Things.Count == 0)
+                throw new InvalidDataException("No pantry found in demo.settings.json (type='pantry').");
+
+            WorldState.Selected = WorldState.Things.Values.First();
+            _logger.World($"Selected pantry {WorldState.Selected.Id} capacity={WorldState.Selected.Inventory.Capacity}");
+            return WorldState.Selected;
+        }
+
+        [Serializable]
+        private sealed class TempRoot
+        {
+            public TempPlacement placements;
+        }
+
+        [Serializable]
+        private sealed class TempPlacement
+        {
+            public List<ThingDef> things;
+        }
+    }
+
+    public static class GameServiceCollectionExtensions
+    {
+        public static IServiceCollection AddGameServices(this IServiceCollection services)
+        {
+            services.AddSingleton<IWorldLogger, WorldLogger>();
+            services.AddSingleton<IContentValidationService, ContentValidationService>();
+            services.AddSingleton<IPanelSettingsProvider, ResourcesPanelSettingsProvider>();
+            services.AddSingleton<IWorldLoader, PantryWorldLoader>();
+            services.AddSingleton<InventoryGridPresenter>();
+            return services;
+        }
+    }
+}

--- a/Assets/Scripts/Sim/World/GameServices.cs.meta
+++ b/Assets/Scripts/Sim/World/GameServices.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d2f6a12fd95f42548c0a1300b8f5d2a4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -6,6 +6,9 @@ EditorBuildSettings:
   serializedVersion: 2
   m_Scenes:
   - enabled: 1
+    path: Assets/Scenes/Boot.unity
+    guid: 27266f9e20796744b83c8590b7e81046
+  - enabled: 0
     path: Assets/Scenes/SampleScene.unity
     guid: 2cda990e2423bbf4892e6590ba056729
   m_configObjects: {}

--- a/packages.config
+++ b/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Bcl.AsyncInterfaces" version="9.0.9" targetFramework="net471" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="5.0.2" targetFramework="net471" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net471" />
   <package id="System.IO.Pipelines" version="9.0.9" targetFramework="net471" />
   <package id="System.Memory" version="4.5.5" targetFramework="net471" />


### PR DESCRIPTION
## Summary
- add a dedicated Boot scene that instantiates the GameBootstrap MonoBehaviour as the game entry point
- refactor GameBootstrap to build a Microsoft.Extensions.DependencyInjection service provider that wires logging, validation, UI, and world loading services
- introduce reusable service abstractions for logging, panel settings, and pantry world loading while enabling the new scene in build settings and referencing the DI package

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e47c9576b483229c4d2e7275059e42