### PR TITLE
Add deterministic world time, map loading, and data-driven spawners

### DIFF
--- a/Assets/Data/world/calendar.json
+++ b/Assets/Data/world/calendar.json
@@ -1,0 +1,54 @@
+{
+  "tickRate": 10,
+  "ticksPerDay": 240,
+  "dayNight": {
+    "sunriseTick": 60,
+    "sunsetTick": 180
+  },
+  "seasons": [
+    {
+      "name": "Spring",
+      "lengthDays": 30,
+      "holidays": [
+        {
+          "name": "Flower Festival",
+          "day": 5
+        },
+        {
+          "name": "Planting Day",
+          "day": 15
+        }
+      ]
+    },
+    {
+      "name": "Summer",
+      "lengthDays": 30,
+      "holidays": [
+        {
+          "name": "Midsummer Faire",
+          "day": 12
+        }
+      ]
+    },
+    {
+      "name": "Autumn",
+      "lengthDays": 30,
+      "holidays": [
+        {
+          "name": "Harvest Feast",
+          "day": 10
+        }
+      ]
+    },
+    {
+      "name": "Winter",
+      "lengthDays": 30,
+      "holidays": [
+        {
+          "name": "Winter's Eve",
+          "day": 20
+        }
+      ]
+    }
+  ]
+}

--- a/Assets/Data/world/calendar.json.meta
+++ b/Assets/Data/world/calendar.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4e3f3c284bf64a75aa32c4f3a02f24b8
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Sim/World/GameBootstrap.cs
+++ b/Assets/Scripts/Sim/World/GameBootstrap.cs
@@ -10,6 +10,9 @@ namespace Sim.World
         private VisualElement _root;
         private InventoryGridPresenter _inventoryUI;
         private GameServices _services;
+        private WorldTimeSystem _timeSystem;
+        private MapLoader _mapLoader;
+        private VillageSpawner _villageSpawner;
 
         public string DemoSettingsPath = "Assets/Data/demo.settings.json";
         public string ItemsPath = "Assets/Data/goap/items.json";
@@ -46,6 +49,32 @@ namespace Sim.World
             _inventoryUI = _services.InventoryGridPresenter;
             _root.Add(_inventoryUI.Root);
 
+            _timeSystem = gameObject.AddComponent<WorldTimeSystem>();
+            _timeSystem.CalendarPath = "Assets/Data/world/calendar.json";
+            _timeSystem.DayChanged += OnWorldDayChanged;
+            _timeSystem.SeasonChanged += OnWorldSeasonChanged;
+            _timeSystem.HolidayStarted += OnWorldHolidayStarted;
+
+            OnWorldSeasonChanged(_timeSystem.CurrentSeason);
+            OnWorldDayChanged(_timeSystem.DayOfYear);
+
+            var worldRoot = CreateChildTransform("World");
+            var tileRoot = CreateChildTransform("Tiles", worldRoot);
+
+            _mapLoader = gameObject.AddComponent<MapLoader>();
+            _mapLoader.VillageDataPath = "Assets/Data/world/village_data.json";
+            _mapLoader.TileParent = tileRoot;
+
+            _villageSpawner = gameObject.AddComponent<VillageSpawner>();
+            _villageSpawner.MapLoader = _mapLoader;
+            _villageSpawner.Logger = logger;
+            _villageSpawner.VillageDataPath = _mapLoader.VillageDataPath;
+
+            var markerRoot = CreateChildTransform("Markers", worldRoot);
+            _villageSpawner.HouseholdParent = CreateChildTransform("Households", markerRoot);
+            _villageSpawner.JobParent = CreateChildTransform("Jobs", markerRoot);
+            _villageSpawner.PointOfInterestParent = CreateChildTransform("PointsOfInterest", markerRoot);
+
             var worldLoader = _services.WorldLoader;
             var selected = worldLoader.LoadDemoWorld(DemoSettingsPath);
             if (selected?.Inventory != null)
@@ -55,8 +84,53 @@ namespace Sim.World
             }
         }
 
+        private Transform CreateChildTransform(string name, Transform parent = null)
+        {
+            var go = new GameObject(string.IsNullOrWhiteSpace(name) ? "Node" : name);
+            go.transform.SetParent(parent == null ? transform : parent, false);
+            return go.transform;
+        }
+
+        private void OnWorldDayChanged(int day)
+        {
+            var logger = _services?.WorldLogger;
+            if (logger == null)
+                return;
+
+            var seasonName = _timeSystem?.CurrentSeason?.Definition?.name ?? "Unknown";
+            logger.World($"Day {day} of {seasonName} has begun.");
+        }
+
+        private void OnWorldSeasonChanged(CalendarSeasonState season)
+        {
+            var logger = _services?.WorldLogger;
+            if (logger == null)
+                return;
+
+            var name = season?.Definition?.name ?? "Unknown";
+            logger.World($"Season changed to {name}.");
+        }
+
+        private void OnWorldHolidayStarted(CalendarHoliday holiday)
+        {
+            var logger = _services?.WorldLogger;
+            if (logger == null)
+                return;
+
+            var name = holiday?.name ?? "Unnamed Holiday";
+            logger.World($"Holiday {name} begins.");
+        }
+
+
         void OnDestroy()
         {
+            if (_timeSystem != null)
+            {
+                _timeSystem.DayChanged -= OnWorldDayChanged;
+                _timeSystem.SeasonChanged -= OnWorldSeasonChanged;
+                _timeSystem.HolidayStarted -= OnWorldHolidayStarted;
+            }
+
             _services?.Dispose();
             _services = null;
         }

--- a/Assets/Scripts/Sim/World/MapLoader.cs
+++ b/Assets/Scripts/Sim/World/MapLoader.cs
@@ -3,83 +3,72 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using UnityEngine;
 using Sim.Config;
-using Sim.Logging;
 
 namespace Sim.World
 {
-    [Serializable]
-    public class VillageData
-    {
-        public MapSection map;
-        public PlacementSection placements;
-
-        [Serializable]
-        public class MapSection
-        {
-            public Dictionary<string, string> key; // TILE_NAME -> #RRGGBB
-            public string mapPng; // optional
-        }
-
-        [Serializable]
-        public class PlacementSection
-        {
-            public List<ThingDef> things;
-        }
-    }
-
     public class MapLoader : MonoBehaviour
     {
+        private const string DefaultVillageDataPath = "Assets/Data/world/village_data.json";
+        private const string DefaultMapPng = "Assets/Data/world/village_map_1000x1000.png";
+
         public Texture2D SourceMap;
-        public string VillageDataPath = "Assets/Data/world/village_data.json";
+        public string VillageDataPath = DefaultVillageDataPath;
+        public Transform TileParent;
+        public float TileSize = 1f;
+        public Material TileMaterial;
 
-        private Dictionary<Color32, string> _colorToTile = new Dictionary<Color32, string>();
+        private readonly Dictionary<Color32, string> _colorToTile = new Dictionary<Color32, string>();
+        private readonly Dictionary<Color32, Material> _materialCache = new Dictionary<Color32, Material>();
+        private VillageData _villageData;
+        private bool _tilesBuilt;
 
-        void Awake()
+        public VillageData Data => _villageData;
+
+        private void Awake()
         {
-            if (SourceMap == null)
-            {
-                // Try to load the PNG mentioned in the JSON if provided
-                var vdata = ConfigLoader.LoadJson<VillageData>(VillageDataPath);
-                if (vdata.map == null || vdata.map.key == null)
-                    throw new InvalidDataException("village_data.json missing map.key");
-                BuildColorIndex(vdata.map.key);
-
-                var pngFile = vdata.map?.mapPng;
-                string pngRelativePath;
-                if (!string.IsNullOrWhiteSpace(pngFile) && pngFile.StartsWith("Assets/", StringComparison.Ordinal))
-                    pngRelativePath = pngFile;
-                else if (!string.IsNullOrWhiteSpace(pngFile))
-                    pngRelativePath = $"Assets/Data/world/{pngFile}";
-                else
-                    pngRelativePath = "Assets/Data/world/village_map_1000x1000.png";
-
-                var pngPath = ConfigLoader.GetAbsolutePath(pngRelativePath);
-                if (!File.Exists(pngPath))
-                    throw new FileNotFoundException("Map PNG not found", pngPath);
-
-                var bytes = File.ReadAllBytes(pngPath);
-                SourceMap = new Texture2D(2, 2, TextureFormat.RGBA32, false, true);
-                if (!SourceMap.LoadImage(bytes, markNonReadable: false))
-                    throw new InvalidDataException("Failed to load map PNG bytes");
-                SourceMap.filterMode = FilterMode.Point;
-            }
-            Log.World("MapLoader initialized.");
+            LoadVillageData();
+            LoadTextureIfNeeded();
         }
 
-        private static Color32 HexToColor32(string hex)
+        private void Start()
         {
-            // Accept "#RRGGBB" (no alpha) or "#RRGGBBAA"
-            if (string.IsNullOrEmpty(hex)) throw new ArgumentException("hex required");
-            var h = hex.Trim().TrimStart('#');
-            if (h.Length == 6) h += "FF";
-            byte r = byte.Parse(h.Substring(0, 2), System.Globalization.NumberStyles.HexNumber);
-            byte g = byte.Parse(h.Substring(2, 2), System.Globalization.NumberStyles.HexNumber);
-            byte b = byte.Parse(h.Substring(4, 2), System.Globalization.NumberStyles.HexNumber);
-            byte a = byte.Parse(h.Substring(6, 2), System.Globalization.NumberStyles.HexNumber);
-            return new Color32(r, g, b, a);
+            BuildTiles();
+        }
+
+        private void LoadVillageData()
+        {
+            var path = string.IsNullOrWhiteSpace(VillageDataPath) ? DefaultVillageDataPath : VillageDataPath;
+            _villageData = ConfigLoader.LoadJson<VillageData>(path);
+
+            if (_villageData?.map?.key == null || _villageData.map.key.Count == 0)
+                throw new InvalidDataException("village_data.json missing map.key definition");
+
+            BuildColorIndex(_villageData.map.key);
+        }
+
+        private void LoadTextureIfNeeded()
+        {
+            if (SourceMap != null)
+                return;
+
+            var mapPng = _villageData?.map?.mapPng;
+            if (string.IsNullOrWhiteSpace(mapPng))
+                mapPng = DefaultMapPng;
+
+            if (!mapPng.StartsWith("Assets/", StringComparison.Ordinal))
+                mapPng = "Assets/" + mapPng.TrimStart('/');
+
+            var pngPath = ConfigLoader.GetAbsolutePath(mapPng);
+            if (!File.Exists(pngPath))
+                throw new FileNotFoundException("Map PNG not found", pngPath);
+
+            var bytes = File.ReadAllBytes(pngPath);
+            SourceMap = new Texture2D(2, 2, TextureFormat.RGBA32, false, true);
+            if (!SourceMap.LoadImage(bytes, markNonReadable: false))
+                throw new InvalidDataException("Failed to load map PNG bytes");
+            SourceMap.filterMode = FilterMode.Point;
         }
 
         private void BuildColorIndex(Dictionary<string, string> key)
@@ -87,17 +76,123 @@ namespace Sim.World
             _colorToTile.Clear();
             foreach (var kvp in key)
             {
-                var c = HexToColor32(kvp.Value);
-                _colorToTile[c] = kvp.Key;
+                var color = HexToColor32(kvp.Value);
+                if (!_colorToTile.ContainsKey(color))
+                {
+                    _colorToTile[color] = kvp.Key;
+                }
             }
+        }
+
+        private static Color32 HexToColor32(string hex)
+        {
+            if (string.IsNullOrWhiteSpace(hex))
+                throw new ArgumentException("Hex color is required", nameof(hex));
+
+            var trimmed = hex.Trim().TrimStart('#');
+            if (trimmed.Length == 6)
+                trimmed += "FF";
+            if (trimmed.Length != 8)
+                throw new ArgumentException($"Invalid hex color length for '{hex}'", nameof(hex));
+
+            byte Parse(string slice) => byte.Parse(slice, System.Globalization.NumberStyles.HexNumber);
+
+            var r = Parse(trimmed.Substring(0, 2));
+            var g = Parse(trimmed.Substring(2, 2));
+            var b = Parse(trimmed.Substring(4, 2));
+            var a = Parse(trimmed.Substring(6, 2));
+            return new Color32(r, g, b, a);
         }
 
         public string GetTileNameAt(int x, int y)
         {
-            var c = SourceMap.GetPixel(x, y);
-            var c32 = (Color32)c;
-            if (_colorToTile.TryGetValue(c32, out var name)) return name;
+            if (SourceMap == null)
+                throw new InvalidOperationException("Source map not loaded");
+
+            var c32 = (Color32)SourceMap.GetPixel(x, y);
+            if (_colorToTile.TryGetValue(c32, out var name))
+                return name;
+
             throw new InvalidDataException($"Color #{c32.r:X2}{c32.g:X2}{c32.b:X2}{c32.a:X2} at {x},{y} not found in tile key.");
+        }
+
+        private void BuildTiles()
+        {
+            if (_tilesBuilt)
+                return;
+
+            if (SourceMap == null)
+                throw new InvalidOperationException("Source map not loaded");
+
+            var parent = EnsureTileParent();
+            var width = SourceMap.width;
+            var height = SourceMap.height;
+            var pixels = SourceMap.GetPixels32();
+
+            if (pixels.Length != width * height)
+                throw new InvalidDataException("Unexpected pixel count in source map");
+
+            var tileSize = Mathf.Max(0.01f, TileSize);
+            for (var y = 0; y < height; y++)
+            {
+                for (var x = 0; x < width; x++)
+                {
+                    var index = y * width + x;
+                    var color = pixels[index];
+                    if (!_colorToTile.TryGetValue(color, out var tileName))
+                        throw new InvalidDataException($"Color #{color.r:X2}{color.g:X2}{color.b:X2}{color.a:X2} at {x},{y} not found in tile key.");
+
+                    var tile = GameObject.CreatePrimitive(PrimitiveType.Quad);
+                    tile.name = $"{tileName}_{x}_{y}";
+                    tile.transform.SetParent(parent, false);
+                    tile.transform.localPosition = new Vector3(x * tileSize, y * tileSize, 0f);
+                    tile.transform.localScale = Vector3.one * tileSize;
+
+                    var collider = tile.GetComponent<Collider>();
+                    if (collider != null)
+                        Destroy(collider);
+
+                    var renderer = tile.GetComponent<MeshRenderer>();
+                    renderer.sharedMaterial = ResolveMaterial(color);
+                }
+            }
+
+            _tilesBuilt = true;
+        }
+
+        private Transform EnsureTileParent()
+        {
+            if (TileParent != null)
+                return TileParent;
+
+            var go = new GameObject("Tiles");
+            go.transform.SetParent(transform, false);
+            TileParent = go.transform;
+            return TileParent;
+        }
+
+        private Material ResolveMaterial(Color32 color)
+        {
+            if (_materialCache.TryGetValue(color, out var cached))
+                return cached;
+
+            Material material;
+            if (TileMaterial != null)
+            {
+                material = new Material(TileMaterial) { color = color };
+            }
+            else
+            {
+                var shader = Shader.Find("Unlit/Color") ?? Shader.Find("Standard");
+                material = new Material(shader);
+                if (material.HasProperty("_Color"))
+                    material.color = color;
+                else if (material.HasProperty("_BaseColor"))
+                    material.SetColor("_BaseColor", color);
+            }
+
+            _materialCache[color] = material;
+            return material;
         }
     }
 }

--- a/Assets/Scripts/Sim/World/Models.cs
+++ b/Assets/Scripts/Sim/World/Models.cs
@@ -59,9 +59,80 @@ namespace Sim.World
         }
     }
 
+    public class Household
+    {
+        public string Id { get; }
+        public string Type { get; }
+        public RectInt Bounds { get; }
+        public Vector2Int Center { get; }
+
+        public Household(string id, string type, RectInt bounds, Vector2Int center)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+                throw new ArgumentException("Id is required", nameof(id));
+            Id = id;
+            Type = type ?? string.Empty;
+            Bounds = bounds;
+            Center = center;
+        }
+    }
+
+    public class JobSite
+    {
+        public string Id { get; }
+        public string Type { get; }
+        public RectInt Bounds { get; }
+        public Vector2Int Center { get; }
+        public List<string> Roles { get; } = new List<string>();
+
+        public JobSite(string id, string type, RectInt bounds, Vector2Int center)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+                throw new ArgumentException("Id is required", nameof(id));
+            Id = id;
+            Type = type ?? string.Empty;
+            Bounds = bounds;
+            Center = center;
+        }
+    }
+
+    public class PointOfInterest
+    {
+        public string Id { get; }
+        public string Name { get; }
+        public RectInt Bounds { get; }
+        public Vector2Int Center { get; }
+
+        public PointOfInterest(string id, string name, RectInt bounds, Vector2Int center)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+                throw new ArgumentException("Id is required", nameof(id));
+            Id = id;
+            Name = string.IsNullOrWhiteSpace(name) ? id : name;
+            Bounds = bounds;
+            Center = center;
+        }
+    }
+
+    public class CalendarState
+    {
+        public int TotalTicks { get; internal set; }
+        public int TicksPerDay { get; internal set; }
+        public int DayOfYear { get; internal set; }
+        public int DayOfSeason { get; internal set; }
+        public string Season { get; internal set; } = string.Empty;
+        public bool IsDaylight { get; internal set; }
+        public float NormalizedTimeOfDay { get; internal set; }
+        public string LastHoliday { get; internal set; } = string.Empty;
+    }
+
     public static class WorldState
     {
         public static readonly Dictionary<string, Thing> Things = new Dictionary<string, Thing>();
+        public static readonly Dictionary<string, Household> Households = new Dictionary<string, Household>();
+        public static readonly Dictionary<string, JobSite> JobSites = new Dictionary<string, JobSite>();
+        public static readonly Dictionary<string, PointOfInterest> PointsOfInterest = new Dictionary<string, PointOfInterest>();
+        public static readonly CalendarState Calendar = new CalendarState();
         public static Thing Selected;
     }
 }

--- a/Assets/Scripts/Sim/World/VillageData.cs
+++ b/Assets/Scripts/Sim/World/VillageData.cs
@@ -1,0 +1,118 @@
+// Assets/Scripts/Sim/World/VillageData.cs
+// C# 8.0
+using System;
+using System.Collections.Generic;
+
+namespace Sim.World
+{
+    [Serializable]
+    public class VillageData
+    {
+        public MapSection map;
+        public PawnSection pawns;
+        public SocialSection social;
+        public Dictionary<string, LocationEntry> locations;
+    }
+
+    [Serializable]
+    public class MapSection
+    {
+        public Dictionary<string, string> key;
+        public string mapPng;
+        public MapAnnotations annotations;
+    }
+
+    [Serializable]
+    public class MapAnnotations
+    {
+        public List<MapBuilding> buildings;
+        public List<MapFeature> features;
+    }
+
+    [Serializable]
+    public class MapBuilding
+    {
+        public string name;
+        public string location;
+    }
+
+    [Serializable]
+    public class MapFeature
+    {
+        public string name;
+        public int[] bbox;
+    }
+
+    [Serializable]
+    public class PawnSection
+    {
+        public PawnMeta meta;
+        public List<VillagePawn> pawns;
+    }
+
+    [Serializable]
+    public class PawnMeta
+    {
+        public string units;
+        public float padding_ft;
+        public float road_width_ft;
+        public float path_width_ft;
+        public float plaza_side_ft;
+        public float fountain_radius_ft;
+    }
+
+    [Serializable]
+    public class VillagePawn
+    {
+        public string id;
+        public string name;
+        public string role;
+        public PawnLocation home;
+        public PawnLocation workplace;
+    }
+
+    [Serializable]
+    public class PawnLocation
+    {
+        public string location;
+    }
+
+    [Serializable]
+    public class SocialSection
+    {
+        public bool enabled;
+        public List<RelationshipType> relationshipTypes;
+        public List<RelationshipSeed> seeds;
+    }
+
+    [Serializable]
+    public class RelationshipType
+    {
+        public string id;
+        public string description;
+        public float minValue;
+        public float maxValue;
+        public float defaultValue;
+        public bool symmetric;
+    }
+
+    [Serializable]
+    public class RelationshipSeed
+    {
+        public string @from;
+        public string to;
+        public string type;
+        public float value;
+        public string notes;
+    }
+
+    [Serializable]
+    public class LocationEntry
+    {
+        public string id;
+        public string type;
+        public string name;
+        public int[] bbox;
+        public int[] center;
+    }
+}

--- a/Assets/Scripts/Sim/World/VillageSpawner.cs
+++ b/Assets/Scripts/Sim/World/VillageSpawner.cs
@@ -1,0 +1,259 @@
+// Assets/Scripts/Sim/World/VillageSpawner.cs
+// C# 8.0
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+using Sim.Config;
+
+namespace Sim.World
+{
+    public class VillageSpawner : MonoBehaviour
+    {
+        private const string DefaultVillageDataPath = "Assets/Data/world/village_data.json";
+
+        public string VillageDataPath = DefaultVillageDataPath;
+        public MapLoader MapLoader;
+        public Transform HouseholdParent;
+        public Transform JobParent;
+        public Transform PointOfInterestParent;
+        public Color HouseholdColor = new Color(0.95f, 0.75f, 0.2f, 1f);
+        public Color JobColor = new Color(0.2f, 0.55f, 0.95f, 1f);
+        public Color PointOfInterestColor = new Color(0.4f, 0.85f, 0.5f, 1f);
+        public float MarkerScale = 0.6f;
+        public float MarkerHeight = 0.5f;
+        public IWorldLogger Logger { get; set; }
+
+        private readonly Dictionary<Color, Material> _materialCache = new Dictionary<Color, Material>();
+
+        private void Awake()
+        {
+            if (MapLoader == null)
+                MapLoader = GetComponent<MapLoader>();
+        }
+
+        private void Start()
+        {
+            var data = ResolveVillageData();
+            if (data == null)
+                throw new InvalidDataException("Village data could not be loaded for spawners");
+
+            SpawnFromData(data);
+        }
+
+        private VillageData ResolveVillageData()
+        {
+            if (MapLoader?.Data != null)
+                return MapLoader.Data;
+
+            var path = string.IsNullOrWhiteSpace(VillageDataPath) ? DefaultVillageDataPath : VillageDataPath;
+            return ConfigLoader.LoadJson<VillageData>(path);
+        }
+
+        private void SpawnFromData(VillageData data)
+        {
+            WorldState.Households.Clear();
+            WorldState.JobSites.Clear();
+            WorldState.PointsOfInterest.Clear();
+
+            var householdIds = SpawnHouseholds(data);
+            var jobIds = SpawnJobs(data);
+            SpawnPointsOfInterest(data, householdIds, jobIds);
+        }
+
+        private HashSet<string> SpawnHouseholds(VillageData data)
+        {
+            var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (data?.locations == null)
+                return ids;
+
+            var parent = EnsureParent(ref HouseholdParent, "Households");
+            foreach (var entry in data.locations.Values)
+            {
+                if (entry == null)
+                    continue;
+
+                if (!IsHousehold(entry.type))
+                    continue;
+
+                if (string.IsNullOrWhiteSpace(entry.id))
+                    continue;
+
+                var rect = ToRect(entry.bbox, entry.id);
+                var center = ToVector(entry.center, entry.id);
+                var household = new Household(entry.id, entry.type, rect, center);
+                WorldState.Households[household.Id] = household;
+                ids.Add(entry.id);
+
+                CreateMarker(parent, $"Household_{entry.id}", center, HouseholdColor);
+            }
+
+            Logger?.World($"Spawned {ids.Count} households from data.");
+            return ids;
+        }
+
+        private HashSet<string> SpawnJobs(VillageData data)
+        {
+            var jobs = new Dictionary<string, JobSite>(StringComparer.OrdinalIgnoreCase);
+            if (data?.pawns?.pawns != null)
+            {
+                foreach (var pawn in data.pawns.pawns)
+                {
+                    if (pawn?.workplace?.location == null)
+                        continue;
+
+                    var locationId = pawn.workplace.location;
+                    if (!data.locations.TryGetValue(locationId, out var location))
+                        throw new InvalidDataException($"Workplace '{locationId}' referenced by pawn '{pawn.id}' not found in locations.");
+
+                    if (!jobs.TryGetValue(locationId, out var jobSite))
+                    {
+                        var rect = ToRect(location.bbox, locationId);
+                        var center = ToVector(location.center, locationId);
+                        jobSite = new JobSite(location.id, location.type, rect, center);
+                        jobs[locationId] = jobSite;
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(pawn.role) && !jobSite.Roles.Contains(pawn.role))
+                        jobSite.Roles.Add(pawn.role);
+                }
+            }
+
+            var parent = EnsureParent(ref JobParent, "Jobs");
+            foreach (var job in jobs.Values)
+            {
+                WorldState.JobSites[job.Id] = job;
+                CreateMarker(parent, $"Job_{job.Id}", job.Center, JobColor);
+            }
+
+            Logger?.World($"Spawned {jobs.Count} job sites from data.");
+            return new HashSet<string>(jobs.Keys, StringComparer.OrdinalIgnoreCase);
+        }
+
+        private void SpawnPointsOfInterest(VillageData data, HashSet<string> householdIds, HashSet<string> jobIds)
+        {
+            var parent = EnsureParent(ref PointOfInterestParent, "PointsOfInterest");
+            var usedIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (householdIds != null)
+                usedIds.UnionWith(householdIds);
+            if (jobIds != null)
+                usedIds.UnionWith(jobIds);
+
+            if (data?.locations != null)
+            {
+                foreach (var entry in data.locations.Values)
+                {
+                    if (entry == null || string.IsNullOrWhiteSpace(entry.id))
+                        continue;
+
+                    if (usedIds.Contains(entry.id))
+                        continue;
+
+                    var rect = ToRect(entry.bbox, entry.id);
+                    var center = ToVector(entry.center, entry.id);
+                    var poi = new PointOfInterest(entry.id, entry.name ?? entry.id, rect, center);
+                    WorldState.PointsOfInterest[poi.Id] = poi;
+                    CreateMarker(parent, $"POI_{entry.id}", center, PointOfInterestColor);
+                }
+            }
+
+            if (data?.map?.annotations?.features != null)
+            {
+                foreach (var feature in data.map.annotations.features)
+                {
+                    if (feature == null || string.IsNullOrWhiteSpace(feature.name))
+                        continue;
+
+                    var rect = ToRect(feature.bbox, feature.name);
+                    var center = new Vector2Int(rect.xMin + rect.width / 2, rect.yMin + rect.height / 2);
+                    var id = $"feature:{feature.name}";
+                    var poi = new PointOfInterest(id, feature.name, rect, center);
+                    WorldState.PointsOfInterest[id] = poi;
+                    CreateMarker(parent, $"POI_{feature.name}", center, PointOfInterestColor);
+                }
+            }
+
+            Logger?.World($"Spawned {WorldState.PointsOfInterest.Count} points of interest from data.");
+        }
+
+        private static bool IsHousehold(string type)
+        {
+            if (string.IsNullOrWhiteSpace(type))
+                return false;
+
+            var lowered = type.ToLowerInvariant();
+            return lowered.Contains("home") || lowered.Contains("house");
+        }
+
+        private Transform EnsureParent(ref Transform parent, string name)
+        {
+            if (parent != null)
+                return parent;
+
+            var go = new GameObject(name);
+            go.transform.SetParent(transform, false);
+            parent = go.transform;
+            return parent;
+        }
+
+        private void CreateMarker(Transform parent, string name, Vector2Int center, Color color)
+        {
+            var marker = GameObject.CreatePrimitive(PrimitiveType.Cylinder);
+            marker.name = name;
+            marker.transform.SetParent(parent, false);
+
+            var tileSize = MapLoader != null ? Mathf.Max(0.01f, MapLoader.TileSize) : 1f;
+            var scale = Mathf.Max(0.01f, MarkerScale) * tileSize;
+            marker.transform.localScale = new Vector3(scale, MarkerHeight, scale);
+            marker.transform.localPosition = new Vector3(center.x * tileSize, center.y * tileSize, -0.1f);
+
+            var collider = marker.GetComponent<Collider>();
+            if (collider != null)
+                Destroy(collider);
+
+            var renderer = marker.GetComponent<MeshRenderer>();
+            renderer.sharedMaterial = ResolveMaterial(color);
+        }
+
+        private Material ResolveMaterial(Color color)
+        {
+            if (_materialCache.TryGetValue(color, out var cached))
+                return cached;
+
+            var shader = Shader.Find("Unlit/Color") ?? Shader.Find("Standard");
+            var material = new Material(shader);
+            if (material.HasProperty("_Color"))
+                material.color = color;
+            else if (material.HasProperty("_BaseColor"))
+                material.SetColor("_BaseColor", color);
+
+            _materialCache[color] = material;
+            return material;
+        }
+
+        private static RectInt ToRect(int[] bbox, string id)
+        {
+            if (bbox == null || bbox.Length != 4)
+                throw new InvalidDataException($"Location '{id}' missing bbox");
+
+            var xMin = bbox[0];
+            var yMin = bbox[1];
+            var xMax = bbox[2];
+            var yMax = bbox[3];
+            if (xMax < xMin || yMax < yMin)
+                throw new InvalidDataException($"Location '{id}' has invalid bbox");
+
+            var width = Math.Max(1, xMax - xMin);
+            var height = Math.Max(1, yMax - yMin);
+            return new RectInt(xMin, yMin, width, height);
+        }
+
+        private static Vector2Int ToVector(int[] center, string id)
+        {
+            if (center == null || center.Length < 2)
+                throw new InvalidDataException($"Location '{id}' missing center");
+
+            return new Vector2Int(center[0], center[1]);
+        }
+    }
+}

--- a/Assets/Scripts/Sim/World/WorldTimeSystem.cs
+++ b/Assets/Scripts/Sim/World/WorldTimeSystem.cs
@@ -1,0 +1,254 @@
+// Assets/Scripts/Sim/World/WorldTimeSystem.cs
+// C# 8.0
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+using Sim.Config;
+
+namespace Sim.World
+{
+    [Serializable]
+    public class CalendarDefinition
+    {
+        public float tickRate = 10f;
+        public int ticksPerDay = 240;
+        public DayNightDefinition dayNight;
+        public List<CalendarSeason> seasons;
+    }
+
+    [Serializable]
+    public class DayNightDefinition
+    {
+        public int sunriseTick = 0;
+        public int sunsetTick = 120;
+    }
+
+    [Serializable]
+    public class CalendarSeason
+    {
+        public string name;
+        public int lengthDays;
+        public List<CalendarHoliday> holidays;
+    }
+
+    [Serializable]
+    public class CalendarHoliday
+    {
+        public string name;
+        public int day; // 1-based within the season
+    }
+
+    public sealed class WorldTimeSystem : MonoBehaviour
+    {
+        private const string DefaultCalendarPath = "Assets/Data/world/calendar.json";
+
+        public string CalendarPath = DefaultCalendarPath;
+
+        public event Action<int> Tick;
+        public event Action<int> DayChanged;
+        public event Action<CalendarSeasonState> SeasonChanged;
+        public event Action<CalendarHoliday> HolidayStarted;
+
+        private CalendarDefinition _definition;
+        private readonly List<CalendarSeasonState> _seasons = new List<CalendarSeasonState>();
+        private float _tickInterval = 0.1f;
+        private float _accumulator;
+        private int _ticksPerDay = 240;
+        private int _tickOfDay;
+        private int _dayOfYear;
+        private int _seasonIndex;
+        private int _daysInYear;
+
+        public int TotalTicks { get; private set; }
+        public float NormalizedTimeOfDay => _ticksPerDay > 0 ? _tickOfDay / (float)_ticksPerDay : 0f;
+        public bool IsDaylight => _definition?.dayNight == null || (_tickOfDay >= _definition.dayNight.sunriseTick && _tickOfDay < _definition.dayNight.sunsetTick);
+        public CalendarSeasonState CurrentSeason => _seasons.Count > 0 ? _seasons[_seasonIndex] : null;
+        public int DayOfSeason => CurrentSeason == null ? 0 : (_dayOfYear - CurrentSeason.StartDay) + 1;
+        public int DayOfYear => _dayOfYear + 1;
+
+        private void Awake()
+        {
+            LoadDefinition();
+            InitializeState();
+        }
+
+        private void Update()
+        {
+            _accumulator += Time.deltaTime;
+            while (_accumulator >= _tickInterval)
+            {
+                _accumulator -= _tickInterval;
+                AdvanceTick();
+            }
+        }
+
+        private void LoadDefinition()
+        {
+            var path = string.IsNullOrWhiteSpace(CalendarPath) ? DefaultCalendarPath : CalendarPath;
+            _definition = ConfigLoader.LoadJson<CalendarDefinition>(path);
+
+            if (_definition == null)
+                throw new InvalidDataException("Calendar definition missing");
+            if (_definition.ticksPerDay <= 0)
+                throw new InvalidDataException("calendar.json must define ticksPerDay > 0");
+            if (_definition.seasons == null || _definition.seasons.Count == 0)
+                throw new InvalidDataException("calendar.json must define at least one season");
+
+            _tickInterval = 1f / Mathf.Max(0.1f, _definition.tickRate <= 0 ? 10f : _definition.tickRate);
+            _ticksPerDay = _definition.ticksPerDay;
+
+            BuildSeasonIndex(_definition.seasons);
+        }
+
+        private void BuildSeasonIndex(List<CalendarSeason> seasons)
+        {
+            _seasons.Clear();
+            _daysInYear = 0;
+
+            for (var i = 0; i < seasons.Count; i++)
+            {
+                var season = seasons[i];
+                if (season == null)
+                    throw new InvalidDataException($"Season at index {i} is null");
+                if (season.lengthDays <= 0)
+                    throw new InvalidDataException($"Season '{season.name}' must have lengthDays > 0");
+
+                var state = new CalendarSeasonState(season, _daysInYear);
+                _seasons.Add(state);
+                _daysInYear += season.lengthDays;
+
+                ValidateHolidays(state);
+            }
+
+            if (_daysInYear <= 0)
+                throw new InvalidDataException("Calendar must cover at least one day");
+        }
+
+        private void ValidateHolidays(CalendarSeasonState season)
+        {
+            if (season.Definition?.holidays == null)
+                return;
+
+            foreach (var holiday in season.Definition.holidays)
+            {
+                if (holiday == null)
+                    throw new InvalidDataException($"Season '{season.Definition.name}' has null holiday definition");
+                if (holiday.day <= 0 || holiday.day > season.Definition.lengthDays)
+                    throw new InvalidDataException($"Holiday '{holiday.name}' in season '{season.Definition.name}' has invalid day {holiday.day}");
+            }
+        }
+
+        private void InitializeState()
+        {
+            TotalTicks = 0;
+            _tickOfDay = 0;
+            _dayOfYear = 0;
+            _seasonIndex = 0;
+
+            if (_seasons.Count == 0)
+                return;
+
+            var season = _seasons[_seasonIndex];
+            UpdateCalendarState(season);
+            WorldState.Calendar.LastHoliday = string.Empty;
+            SeasonChanged?.Invoke(season);
+        }
+
+        private void AdvanceTick()
+        {
+            TotalTicks++;
+            _tickOfDay++;
+
+            if (_tickOfDay >= _ticksPerDay)
+            {
+                _tickOfDay = 0;
+                AdvanceDay();
+            }
+            else
+            {
+                UpdateCalendarState(CurrentSeason);
+            }
+
+            Tick?.Invoke(TotalTicks);
+        }
+
+        private void AdvanceDay()
+        {
+            _dayOfYear++;
+            if (_dayOfYear >= _daysInYear)
+                _dayOfYear = 0;
+
+            var newSeasonIndex = GetSeasonIndexForDay(_dayOfYear);
+            if (newSeasonIndex != _seasonIndex)
+            {
+                _seasonIndex = newSeasonIndex;
+                var season = _seasons[_seasonIndex];
+                UpdateCalendarState(season);
+                SeasonChanged?.Invoke(season);
+            }
+            else
+            {
+                UpdateCalendarState(CurrentSeason);
+            }
+
+            DayChanged?.Invoke(DayOfYear);
+            WorldState.Calendar.LastHoliday = string.Empty;
+            CheckForHoliday();
+        }
+
+        private int GetSeasonIndexForDay(int day)
+        {
+            for (var i = 0; i < _seasons.Count; i++)
+            {
+                var season = _seasons[i];
+                if (day >= season.StartDay && day < season.EndDay)
+                    return i;
+            }
+
+            return 0;
+        }
+
+        private void CheckForHoliday()
+        {
+            var season = CurrentSeason;
+            if (season?.Definition?.holidays == null)
+                return;
+
+            var dayOfSeason = DayOfSeason;
+            foreach (var holiday in season.Definition.holidays)
+            {
+                if (holiday.day == dayOfSeason)
+                {
+                    WorldState.Calendar.LastHoliday = holiday.name ?? string.Empty;
+                    HolidayStarted?.Invoke(holiday);
+                }
+            }
+        }
+
+        private void UpdateCalendarState(CalendarSeasonState season)
+        {
+            WorldState.Calendar.TotalTicks = TotalTicks;
+            WorldState.Calendar.TicksPerDay = _ticksPerDay;
+            WorldState.Calendar.DayOfYear = DayOfYear;
+            WorldState.Calendar.DayOfSeason = DayOfSeason;
+            WorldState.Calendar.Season = season?.Definition?.name ?? string.Empty;
+            WorldState.Calendar.IsDaylight = IsDaylight;
+            WorldState.Calendar.NormalizedTimeOfDay = NormalizedTimeOfDay;
+        }
+    }
+
+    public sealed class CalendarSeasonState
+    {
+        public CalendarSeason Definition { get; }
+        public int StartDay { get; }
+        public int EndDay { get; }
+
+        public CalendarSeasonState(CalendarSeason definition, int startDay)
+        {
+            Definition = definition;
+            StartDay = startDay;
+            EndDay = startDay + (definition?.lengthDays ?? 0);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a world time system that ticks at a fixed rate, drives day/night, and loads seasons and holidays from calendar data
- build map tiles directly from the village PNG using the strict color key defined in village_data.json
- spawn households, job sites, and points of interest from the village data into world state and scene markers

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68e480cf7594832281b49834d3a865ca