### PR TITLE
Fix map tiles to face the camera

### DIFF
--- a/Assets/Scripts/Sim/World/MapLoader.cs
+++ b/Assets/Scripts/Sim/World/MapLoader.cs
@@ -147,6 +147,7 @@ namespace Sim.World
                     tile.transform.SetParent(parent, false);
                     tile.transform.localPosition = new Vector3(x * tileSize, y * tileSize, 0f);
                     tile.transform.localScale = Vector3.one * tileSize;
+                    tile.transform.localRotation = Quaternion.Euler(0f, 180f, 0f);
 
                     var collider = tile.GetComponent<Collider>();
                     if (collider != null)


### PR DESCRIPTION
## Summary
- rotate generated map tiles so their front sides face the orthographic camera and the village map becomes visible

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4852c2ce883228e742f914a0cacc2