### PR TITLE
Fix demo data loading for updated JSON structures

### DIFF
--- a/Assets/Scripts/Sim/World/GameServices.cs
+++ b/Assets/Scripts/Sim/World/GameServices.cs
@@ -64,6 +64,16 @@ namespace Sim.World
             if (_cached == null)
             {
                 _cached = ScriptableObject.CreateInstance<PanelSettings>();
+                _cached.name = "RuntimePanelSettings";
+            }
+
+            if (_cached.themeStyleSheet == null)
+            {
+                var theme = Resources.Load<ThemeStyleSheet>("PanelSettings/DefaultTheme");
+                if (theme == null)
+                    theme = ScriptableObject.CreateInstance<ThemeStyleSheet>();
+
+                _cached.themeStyleSheet = theme;
             }
 
             return _cached;
@@ -92,12 +102,12 @@ namespace Sim.World
             _logger.World("LoadWorld() begin.");
 
             var root = ConfigLoader.LoadJson<TempRoot>(demoSettingsPath);
-            if (root?.placements?.things == null)
-                throw new InvalidDataException("demo.settings.json missing placements.things");
+            if (root?.world?.things == null)
+                throw new InvalidDataException("demo.settings.json missing world.things");
 
             WorldState.Things.Clear();
 
-            foreach (var td in root.placements.things)
+            foreach (var td in root.world.things)
             {
                 if (td == null || string.IsNullOrEmpty(td.type))
                     continue;
@@ -129,11 +139,11 @@ namespace Sim.World
         [Serializable]
         private sealed class TempRoot
         {
-            public TempPlacement placements;
+            public TempWorld world;
         }
 
         [Serializable]
-        private sealed class TempPlacement
+        private sealed class TempWorld
         {
             public List<ThingDef> things;
         }

--- a/Assets/Scripts/Sim/World/VillageData.cs
+++ b/Assets/Scripts/Sim/World/VillageData.cs
@@ -27,6 +27,7 @@ namespace Sim.World
     {
         public List<MapBuilding> buildings;
         public List<MapFeature> features;
+        public List<MapFarm> farms;
     }
 
     [Serializable]
@@ -41,6 +42,17 @@ namespace Sim.World
     {
         public string name;
         public int[] bbox;
+        public int[] center;
+        public float radius_px;
+    }
+
+    [Serializable]
+    public class MapFarm
+    {
+        public int[] field_bbox;
+        public string type;
+        public int[] farmhouse_bbox;
+        public List<int[]> drive_to_center;
     }
 
     [Serializable]


### PR DESCRIPTION
## Summary
- ensure runtime panel settings provide a theme style sheet fallback so the UI document renders
- update the demo world loader to read the new world.things hierarchy
- expand village data models and spawner logic to handle new annotation shapes and avoid JSON binding failures

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68e486f1c8788322bcbf724e566a01ae