### PR TITLE
Fix PanelSettings theme list access

### DIFF
--- a/Assets/Scripts/Sim/World/GameServices.cs
+++ b/Assets/Scripts/Sim/World/GameServices.cs
@@ -78,15 +78,15 @@ namespace Sim.World
 
                 _cached.themeStyleSheet = theme;
 
-                var themeList = _cached.themeStyleSheets;
+                var field = typeof(PanelSettings).GetField("m_ThemeStyleSheets", BindingFlags.Instance | BindingFlags.NonPublic);
+                var themeList = field?.GetValue(_cached) as List<ThemeStyleSheet>;
                 if (themeList == null)
                 {
                     themeList = new List<ThemeStyleSheet>();
-                    var field = typeof(PanelSettings).GetField("m_ThemeStyleSheets", BindingFlags.Instance | BindingFlags.NonPublic);
                     field?.SetValue(_cached, themeList);
                 }
 
-                if (themeList != null && !themeList.Contains(theme))
+                if (!themeList.Contains(theme))
                 {
                     themeList.Clear();
                     themeList.Add(theme);


### PR DESCRIPTION
## Summary
- fetch the panel theme list via reflection instead of using the removed themeStyleSheets property
- ensure the runtime panel settings always have a valid theme list

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e489ffaaf4832297cf1dd53664bbb1