### PR TITLE
Restore data assets and extend schema support

### DIFF
--- a/Assets/Resources/PanelSettings.meta
+++ b/Assets/Resources/PanelSettings.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2a89e98b28434649b1f7bde36ed96a9f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/PanelSettings/DefaultTheme.tss
+++ b/Assets/Resources/PanelSettings/DefaultTheme.tss
@@ -1,0 +1,8 @@
+:root {
+  --unity-font-style-and-weight: normal;
+  --unity-font-size: 14;
+}
+
+.inventory-grid-slot {
+  unity-font-style: normal;
+}

--- a/Assets/Resources/PanelSettings/DefaultTheme.tss.meta
+++ b/Assets/Resources/PanelSettings/DefaultTheme.tss.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 74e6b5f93a1a4c00a342d2534a1f2f01
+ScriptedImporter:
+  version: 2
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Sim/World/GameServices.cs
+++ b/Assets/Scripts/Sim/World/GameServices.cs
@@ -164,7 +164,7 @@ namespace Sim.World
         {
             public List<ThingDef> things;
             [JsonExtensionData]
-            public IDictionary<string, JToken> Extra;
+            public IDictionary<string, JToken> Extra { get; set; }
         }
     }
 

--- a/Assets/Scripts/Sim/World/Models.cs
+++ b/Assets/Scripts/Sim/World/Models.cs
@@ -2,6 +2,8 @@
 // C# 8.0
 using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using UnityEngine;
 
 namespace Sim.World
@@ -15,6 +17,9 @@ namespace Sim.World
         public int x;
         public int y;
         public Dictionary<string, float> attributes;
+
+        [JsonExtensionData]
+        public IDictionary<string, JToken> Extra { get; set; }
     }
 
     [Serializable]

--- a/Assets/Scripts/Sim/World/VillageData.cs
+++ b/Assets/Scripts/Sim/World/VillageData.cs
@@ -2,6 +2,8 @@
 // C# 8.0
 using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Sim.World
 {
@@ -81,6 +83,8 @@ namespace Sim.World
         public string role;
         public PawnLocation home;
         public PawnLocation workplace;
+        public PawnInventory inventory;
+        public float currency;
     }
 
     [Serializable]
@@ -88,6 +92,28 @@ namespace Sim.World
     {
         public string location;
         public string type;
+        public int[] bbox;
+        public int[] center;
+        public float radius_px;
+    }
+
+    [Serializable]
+    public class PawnInventory
+    {
+        public int slots;
+        public int stackSize;
+        public List<PawnInventoryItem> start;
+    }
+
+    [Serializable]
+    public class PawnInventoryItem
+    {
+        public string item;
+        public string id;
+        public int quantity;
+
+        [JsonExtensionData]
+        public IDictionary<string, JToken> Extra { get; set; }
     }
 
     [Serializable]


### PR DESCRIPTION
## Summary
- restore the full `demo.settings.json` and `world/village_data.json` datasets so no authored content is lost
- extend the world data models to understand pawn inventory/currency fields and location geometry metadata
- relax the demo world loader models so additional metadata in the JSON no longer causes strict binding failures

## Testing
- Not run (Unity editor/runtime unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e48a8b68588322ba4effa6bed57052