### PR TITLE
Handle additional world metadata in demo settings

### DIFF
--- a/Assets/Scripts/Sim/World/GameServices.cs
+++ b/Assets/Scripts/Sim/World/GameServices.cs
@@ -162,7 +162,21 @@ namespace Sim.World
         [Serializable]
         private sealed class TempWorld
         {
+            // The demo settings JSON includes a large number of fields under "world".
+            // We only need "things" for now, but because ConfigLoader is configured to
+            // fail on unknown members we must explicitly surface any known top-level
+            // fields that appear in the file.  Everything else is captured via
+            // JsonExtensionData so future additions continue to deserialize without
+            // changes here.
+            public int width;
+            public int height;
+            public float blockedChance;
+            public int shards;
+            public int rngSeed;
+            public JToken map;
+            public JToken facts;
             public List<ThingDef> things;
+
             [JsonExtensionData]
             public IDictionary<string, JToken> Extra { get; set; }
         }


### PR DESCRIPTION
## Summary
- allow the pantry world loader to accept the world metadata fields present in the demo settings JSON
- capture any future fields under world via JsonExtensionData so strict deserialization continues to work

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e48d981f1c8322bac61aed30e03d8b