### PR TITLE
Ensure runtime panel settings load theme and support container JSON

### DIFF
--- a/Assets/Scripts/Sim/World/Models.cs
+++ b/Assets/Scripts/Sim/World/Models.cs
@@ -17,6 +17,26 @@ namespace Sim.World
         public int x;
         public int y;
         public Dictionary<string, float> attributes;
+        public ThingContainerDef container;
+
+        [JsonExtensionData]
+        public IDictionary<string, JToken> Extra { get; set; }
+    }
+
+    [Serializable]
+    public class ThingContainerDef
+    {
+        public ThingInventoryDef inventory;
+
+        [JsonExtensionData]
+        public IDictionary<string, JToken> Extra { get; set; }
+    }
+
+    [Serializable]
+    public class ThingInventoryDef
+    {
+        public int slots;
+        public int stackSize;
 
         [JsonExtensionData]
         public IDictionary<string, JToken> Extra { get; set; }


### PR DESCRIPTION
## Summary
- ensure the runtime-created panel settings always assigns the default theme style sheet and updates backing lists
- extend thing definitions to include container and inventory data so demo settings deserialize cleanly

## Testing
- not run (project uses Unity editor)

------
https://chatgpt.com/codex/tasks/task_e_68e48f285230832282627b040c93e600