### PR TITLE
Add standalone demo data assets

### DIFF
--- a/Assets/Data/demo.actors.json
+++ b/Assets/Data/demo.actors.json
@@ -1,0 +1,47 @@
+{
+  "count": 41,
+  "type": "human",
+  "tags": [
+    "actor",
+    "human"
+  ],
+  "attributes": {
+    "loneliness": {
+      "min": 0.25,
+      "max": 0.85
+    },
+    "fatigue": {
+      "min": 0.3,
+      "max": 0.6
+    },
+    "aggression": {
+      "min": 0.05,
+      "max": 0.2
+    },
+    "hunger": {
+      "min": 0.25,
+      "max": 0.7
+    },
+    "ingredients": {
+      "value": 0
+    },
+    "health": {
+      "value": 1.0
+    }
+  },
+  "inventory": {
+    "slots": 12,
+    "stackSize": 20,
+    "start": [
+      {
+        "id": "basic_pickaxe",
+        "quantity": 1
+      },
+      {
+        "id": "basic_fishing_rod",
+        "quantity": 1
+      }
+    ]
+  },
+  "currency": 25
+}

--- a/Assets/Data/demo.actors.json.meta
+++ b/Assets/Data/demo.actors.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 62d0bcccd71e44a38bec1137bbf4d7af
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Data/demo.dialogue.json
+++ b/Assets/Data/demo.dialogue.json
@@ -1,0 +1,3 @@
+{
+  "path": "dialogue.json"
+}

--- a/Assets/Data/demo.dialogue.json.meta
+++ b/Assets/Data/demo.dialogue.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c2e311eeb07e4095b3d6d0524fe2ba5b
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Data/demo.events.json
+++ b/Assets/Data/demo.events.json
@@ -1,0 +1,3 @@
+{
+  "path": "events.json"
+}

--- a/Assets/Data/demo.events.json.meta
+++ b/Assets/Data/demo.events.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ff81e05ba12c4dcd95dc19012c12ae24
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Data/demo.farming.json
+++ b/Assets/Data/demo.farming.json
@@ -1,0 +1,3 @@
+{
+  "crops": "crops.json"
+}

--- a/Assets/Data/demo.farming.json.meta
+++ b/Assets/Data/demo.farming.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3bd13db9eaf24aed80df88f79f519059
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Data/demo.fishing.json
+++ b/Assets/Data/demo.fishing.json
@@ -1,0 +1,47 @@
+{
+  "enabled": true,
+  "respawnHours": 6.0,
+  "maxActiveSpots": 14,
+  "spotsPer100Tiles": 3.5,
+  "catches": [
+    {
+      "id": "river_perch",
+      "itemId": "silver_perch",
+      "minQuantity": 1,
+      "maxQuantity": 2,
+      "seasons": [
+        "Spring",
+        "Summer",
+        "Autumn"
+      ],
+      "weather": [
+        "Clear",
+        "Cloudy"
+      ],
+      "shallowOnly": true,
+      "weight": 1.0,
+      "castsPerSpot": 3,
+      "baitItemId": "river_bait",
+      "skill": "fishing",
+      "skillXp": 3.0
+    },
+    {
+      "id": "sunset_salmon",
+      "itemId": "sunset_salmon",
+      "minQuantity": 1,
+      "maxQuantity": 1,
+      "seasons": [
+        "Summer"
+      ],
+      "weather": [
+        "Clear"
+      ],
+      "deepOnly": true,
+      "weight": 0.7,
+      "castsPerSpot": 2,
+      "baitItemId": "river_bait",
+      "skill": "fishing",
+      "skillXp": 5.0
+    }
+  ]
+}

--- a/Assets/Data/demo.fishing.json.meta
+++ b/Assets/Data/demo.fishing.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 74e63adcaba94efc92ac687d02a4c18d
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Data/demo.foraging.json
+++ b/Assets/Data/demo.foraging.json
@@ -1,0 +1,97 @@
+{
+  "enabled": true,
+  "respawnHours": 8.0,
+  "maxActiveSpots": 18,
+  "forestSpotsPer100Tiles": 3.5,
+  "coastSpotsPer100Tiles": 2.4,
+  "resources": [
+    {
+      "id": "spring_berries",
+      "itemId": "wild_berry",
+      "minQuantity": 1,
+      "maxQuantity": 3,
+      "seasons": [
+        "Spring",
+        "Summer"
+      ],
+      "biomes": [
+        "forest"
+      ],
+      "weight": 1.0,
+      "gathersPerSpot": 3,
+      "skill": "foraging",
+      "skillXp": 2.0
+    },
+    {
+      "id": "autumn_mushrooms",
+      "itemId": "forest_mushroom",
+      "minQuantity": 1,
+      "maxQuantity": 2,
+      "seasons": [
+        "Autumn"
+      ],
+      "biomes": [
+        "forest"
+      ],
+      "weight": 0.85,
+      "gathersPerSpot": 2,
+      "skill": "foraging",
+      "skillXp": 3.0
+    },
+    {
+      "id": "winter_lichen",
+      "itemId": "frost_lichen",
+      "minQuantity": 1,
+      "maxQuantity": 2,
+      "seasons": [
+        "Winter"
+      ],
+      "biomes": [
+        "forest"
+      ],
+      "weight": 0.6,
+      "gathersPerSpot": 2,
+      "skill": "foraging",
+      "skillXp": 2.5
+    },
+    {
+      "id": "tidal_shells",
+      "itemId": "sea_shell",
+      "minQuantity": 1,
+      "maxQuantity": 2,
+      "seasons": [
+        "Spring",
+        "Summer",
+        "Autumn"
+      ],
+      "biomes": [
+        "coast"
+      ],
+      "weight": 0.8,
+      "gathersPerSpot": 4,
+      "skill": "foraging",
+      "skillXp": 2.5
+    },
+    {
+      "id": "storm_driftwood",
+      "itemId": "driftwood_bundle",
+      "minQuantity": 1,
+      "maxQuantity": 1,
+      "seasons": [
+        "Autumn",
+        "Winter"
+      ],
+      "weather": [
+        "Rain",
+        "Storm"
+      ],
+      "biomes": [
+        "coast"
+      ],
+      "weight": 0.7,
+      "gathersPerSpot": 2,
+      "skill": "foraging",
+      "skillXp": 3.0
+    }
+  ]
+}

--- a/Assets/Data/demo.foraging.json.meta
+++ b/Assets/Data/demo.foraging.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5636844e770c4d4ba3e8850f8d802afe
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Data/demo.items.json
+++ b/Assets/Data/demo.items.json
@@ -1,0 +1,4 @@
+{
+  "catalog": "goap/items.json",
+  "recipes": "recipes.json"
+}

--- a/Assets/Data/demo.items.json.meta
+++ b/Assets/Data/demo.items.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c2ba1e74ca86417ab7d8085a2a8b161f
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Data/demo.livestock.json
+++ b/Assets/Data/demo.livestock.json
@@ -1,0 +1,3 @@
+{
+  "animals": "animals.json"
+}

--- a/Assets/Data/demo.livestock.json.meta
+++ b/Assets/Data/demo.livestock.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c16f442139924195a677cb2c9619c950
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Data/demo.mining.json
+++ b/Assets/Data/demo.mining.json
@@ -1,0 +1,159 @@
+{
+  "enabled": true,
+  "respawnHours": 10.0,
+  "maxActiveNodes": 12,
+  "ores": [
+    {
+      "id": "surface_copper",
+      "itemId": "copper_ore",
+      "minQuantity": 1,
+      "maxQuantity": 2,
+      "seasons": [
+        "Spring",
+        "Summer",
+        "Autumn"
+      ],
+      "weather": [
+        "Clear",
+        "Cloudy",
+        "Rain"
+      ],
+      "biomes": [
+        "mountain",
+        "forest"
+      ],
+      "weight": 1.0,
+      "hitsPerNode": 3,
+      "requiredToolId": "",
+      "requiredToolTier": 0,
+      "skill": "mining",
+      "skillXp": 5.0
+    },
+    {
+      "id": "deep_iron",
+      "itemId": "iron_ore",
+      "minQuantity": 1,
+      "maxQuantity": 2,
+      "seasons": [
+        "Autumn",
+        "Winter"
+      ],
+      "weather": [
+        "Clear",
+        "Cloudy",
+        "Storm"
+      ],
+      "biomes": [
+        "mountain",
+        "cavern"
+      ],
+      "weight": 0.75,
+      "hitsPerNode": 4,
+      "requiredToolId": "",
+      "requiredToolTier": 1,
+      "skill": "mining",
+      "skillXp": 6.0
+    },
+    {
+      "id": "coal_seam",
+      "itemId": "coal_chunk",
+      "minQuantity": 1,
+      "maxQuantity": 3,
+      "seasons": [
+        "Spring",
+        "Summer",
+        "Autumn",
+        "Winter"
+      ],
+      "weather": [
+        "Clear",
+        "Cloudy",
+        "Rain",
+        "Storm"
+      ],
+      "biomes": [
+        "mountain",
+        "cavern"
+      ],
+      "weight": 0.5,
+      "hitsPerNode": 2,
+      "requiredToolId": "",
+      "requiredToolTier": 1,
+      "skill": "mining",
+      "skillXp": 4.5
+    }
+  ],
+  "layers": [
+    {
+      "id": "surface",
+      "oreIds": [
+        "surface_copper",
+        "coal_seam"
+      ],
+      "biomes": [
+        "forest",
+        "mountain"
+      ]
+    },
+    {
+      "id": "deep",
+      "oreIds": [
+        "deep_iron",
+        "coal_seam"
+      ],
+      "biomes": [
+        "mountain",
+        "cavern"
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "id": "mine_north_entrance",
+      "type": "mine_node",
+      "tags": [
+        "mine_node",
+        "resource",
+        "service_point"
+      ],
+      "x": 612,
+      "y": 198,
+      "layer": "surface",
+      "biomes": [
+        "mountain"
+      ]
+    },
+    {
+      "id": "mine_central_chamber",
+      "type": "mine_node",
+      "tags": [
+        "mine_node",
+        "resource",
+        "service_point"
+      ],
+      "x": 618,
+      "y": 204,
+      "layer": "deep",
+      "biomes": [
+        "mountain",
+        "cavern"
+      ]
+    },
+    {
+      "id": "mine_western_shaft",
+      "type": "mine_node",
+      "tags": [
+        "mine_node",
+        "resource",
+        "service_point"
+      ],
+      "x": 604,
+      "y": 210,
+      "layer": "surface",
+      "biomes": [
+        "forest",
+        "mountain"
+      ]
+    }
+  ]
+}

--- a/Assets/Data/demo.mining.json.meta
+++ b/Assets/Data/demo.mining.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4bf3e03176e34882bc19cbb55cab01a6
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Data/demo.needs.json
+++ b/Assets/Data/demo.needs.json
@@ -1,0 +1,25 @@
+{
+  "enabled": true,
+  "needs": [
+    {
+      "id": "fatigue_daily",
+      "attribute": "fatigue",
+      "changePerTrigger": 0.3,
+      "triggersPerDay": 2,
+      "clamp01": true,
+      "targetTags": [
+        "actor"
+      ]
+    },
+    {
+      "id": "hunger_daily",
+      "attribute": "hunger",
+      "changePerTrigger": 0.3,
+      "triggersPerDay": 2,
+      "clamp01": true,
+      "targetTags": [
+        "actor"
+      ]
+    }
+  ]
+}

--- a/Assets/Data/demo.needs.json.meta
+++ b/Assets/Data/demo.needs.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d2ca77557673473fad02d78e18d115ca
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Data/demo.observer.json
+++ b/Assets/Data/demo.observer.json
@@ -1,0 +1,4 @@
+{
+  "cameraPawn": "player",
+  "showOnlySelectedPawn": false
+}

--- a/Assets/Data/demo.observer.json.meta
+++ b/Assets/Data/demo.observer.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2851ff994b744b6ca6cb7354a78dfccd
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Data/demo.persistence.json
+++ b/Assets/Data/demo.persistence.json
@@ -1,0 +1,5 @@
+{
+  "directory": "saves",
+  "saveSlot": "demo",
+  "autosaveMinutes": 10
+}

--- a/Assets/Data/demo.persistence.json.meta
+++ b/Assets/Data/demo.persistence.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 90513e2a13454cfab28fe73f793a51f2
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Data/demo.player.json
+++ b/Assets/Data/demo.player.json
@@ -1,0 +1,33 @@
+{
+  "id": "player",
+  "tags": [
+    "actor",
+    "villager",
+    "player"
+  ],
+  "spawn": {
+    "id": "Bakery"
+  },
+  "inventory": {
+    "slots": 18,
+    "stackSize": 30,
+    "start": [
+      {
+        "id": "basic_pickaxe",
+        "quantity": 1
+      },
+      {
+        "id": "basic_fishing_rod",
+        "quantity": 1
+      }
+    ]
+  },
+  "currency": 50,
+  "attributes": {
+    "hunger": 0.2,
+    "fatigue": 0.1,
+    "loneliness": 0.3
+  },
+  "allowAiFallback": false,
+  "autoEvaluateManualPlans": false
+}

--- a/Assets/Data/demo.player.json.meta
+++ b/Assets/Data/demo.player.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d59f5012530f40d788f325d7df7932cd
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Data/demo.quests.json
+++ b/Assets/Data/demo.quests.json
@@ -1,0 +1,3 @@
+{
+  "path": "quests.json"
+}

--- a/Assets/Data/demo.quests.json.meta
+++ b/Assets/Data/demo.quests.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b3aa1c1e166f4157acdab2f4be62d98d
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Data/demo.schedules.json
+++ b/Assets/Data/demo.schedules.json
@@ -1,0 +1,3 @@
+{
+  "path": "schedules.json"
+}

--- a/Assets/Data/demo.schedules.json.meta
+++ b/Assets/Data/demo.schedules.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ee6fe66b16ee4dc6b7c387e6401a8e49
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Data/demo.settings.json
+++ b/Assets/Data/demo.settings.json
@@ -3944,572 +3944,205 @@
       }
     ],
     "facts": [
-      {"pred": "works_at", "a": "P-0001", "b": "School"},
-      {"pred": "works_at", "a": "P-0002", "b": "School"},
-      {"pred": "works_at", "a": "P-0003", "b": "Library"},
-      {"pred": "works_at", "a": "P-0004", "b": "Church"},
-      {"pred": "works_at", "a": "P-0005", "b": "Bakery"},
-      {"pred": "works_at", "a": "P-0006", "b": "Bakery"},
-      {"pred": "works_at", "a": "P-0007", "b": "MayorHouse"},
-      {"pred": "works_at", "a": "P-0008", "b": "MayorHouse"},
-      {"pred": "works_at", "a": "P-0009", "b": "GeneralStore"},
-      {"pred": "works_at", "a": "P-0010", "b": "GeneralStore"},
-      {"pred": "works_at", "a": "P-0013", "b": "FarmField"},
-      {"pred": "works_at", "a": "P-0014", "b": "FarmField"},
-      {"pred": "works_at", "a": "P-0015", "b": "FarmField"},
-      {"pred": "works_at", "a": "P-0016", "b": "FarmField"},
-      {"pred": "works_at", "a": "P-0017", "b": "FarmField"},
-      {"pred": "works_at", "a": "P-0018", "b": "FarmField"},
-      {"pred": "works_at", "a": "P-0019", "b": "FarmField"},
-      {"pred": "works_at", "a": "P-0020", "b": "FarmField"},
-      {"pred": "works_at", "a": "P-0021", "b": "FarmField"},
-      {"pred": "works_at", "a": "P-0022", "b": "FarmField"},
-      {"pred": "works_at", "a": "P-0023", "b": "FarmField"},
-      {"pred": "works_at", "a": "P-0024", "b": "FarmField"},
-      {"pred": "works_at", "a": "P-0025", "b": "FarmField"},
-      {"pred": "works_at", "a": "P-0026", "b": "FarmField"},
-      {"pred": "works_at", "a": "P-0027", "b": "FarmField"},
-      {"pred": "works_at", "a": "P-0028", "b": "FarmField"},
-      {"pred": "works_at", "a": "P-0029", "b": "FarmField"},
-      {"pred": "works_at", "a": "P-0030", "b": "FarmField"},
-      {"pred": "works_at", "a": "P-0031", "b": "FarmField"},
-      {"pred": "works_at", "a": "P-0032", "b": "FarmField"},
-      {"pred": "works_at", "a": "P-0033", "b": "FarmField"},
-      {"pred": "works_at", "a": "P-0034", "b": "FarmField"},
-      {"pred": "works_at", "a": "P-0035", "b": "FarmField"},
-      {"pred": "works_at", "a": "P-0036", "b": "FarmField"},
-      {"pred": "tag", "a": "P-0102", "b": "animal"},
-      {"pred": "tag", "a": "P-0102", "b": "livestock"},
-      {"pred": "tag", "a": "P-0103", "b": "animal"},
-      {"pred": "tag", "a": "P-0103", "b": "livestock"},
-      {"pred": "tag", "a": "P-0104", "b": "animal"},
-      {"pred": "tag", "a": "P-0104", "b": "livestock"}
-    ]
-  },
-  "items": {
-    "catalog": "goap/items.json",
-    "recipes": "recipes.json"
-  },
-  "farming": {
-    "crops": "crops.json"
-  },
-  "livestock": {
-    "animals": "animals.json"
-  },
-  "fishing": {
-    "enabled": true,
-    "respawnHours": 6.0,
-    "maxActiveSpots": 14,
-    "spotsPer100Tiles": 3.5,
-    "catches": [
       {
-        "id": "river_perch",
-        "itemId": "silver_perch",
-        "minQuantity": 1,
-        "maxQuantity": 2,
-        "seasons": ["Spring", "Summer", "Autumn"],
-        "weather": ["Clear", "Cloudy"],
-        "shallowOnly": true,
-        "weight": 1.0,
-        "castsPerSpot": 3,
-        "baitItemId": "river_bait",
-        "skill": "fishing",
-        "skillXp": 3.0
+        "pred": "works_at",
+        "a": "P-0001",
+        "b": "School"
       },
       {
-        "id": "sunset_salmon",
-        "itemId": "sunset_salmon",
-        "minQuantity": 1,
-        "maxQuantity": 1,
-        "seasons": ["Summer"],
-        "weather": ["Clear"],
-        "deepOnly": true,
-        "weight": 0.7,
-        "castsPerSpot": 2,
-        "baitItemId": "river_bait",
-        "skill": "fishing",
-        "skillXp": 5.0
-      }
-    ]
-  },
-  "foraging": {
-    "enabled": true,
-    "respawnHours": 8.0,
-    "maxActiveSpots": 18,
-    "forestSpotsPer100Tiles": 3.5,
-    "coastSpotsPer100Tiles": 2.4,
-    "resources": [
-      {
-        "id": "spring_berries",
-        "itemId": "wild_berry",
-        "minQuantity": 1,
-        "maxQuantity": 3,
-        "seasons": ["Spring", "Summer"],
-        "biomes": ["forest"],
-        "weight": 1.0,
-        "gathersPerSpot": 3,
-        "skill": "foraging",
-        "skillXp": 2.0
+        "pred": "works_at",
+        "a": "P-0002",
+        "b": "School"
       },
       {
-        "id": "autumn_mushrooms",
-        "itemId": "forest_mushroom",
-        "minQuantity": 1,
-        "maxQuantity": 2,
-        "seasons": ["Autumn"],
-        "biomes": ["forest"],
-        "weight": 0.85,
-        "gathersPerSpot": 2,
-        "skill": "foraging",
-        "skillXp": 3.0
+        "pred": "works_at",
+        "a": "P-0003",
+        "b": "Library"
       },
       {
-        "id": "winter_lichen",
-        "itemId": "frost_lichen",
-        "minQuantity": 1,
-        "maxQuantity": 2,
-        "seasons": ["Winter"],
-        "biomes": ["forest"],
-        "weight": 0.6,
-        "gathersPerSpot": 2,
-        "skill": "foraging",
-        "skillXp": 2.5
+        "pred": "works_at",
+        "a": "P-0004",
+        "b": "Church"
       },
       {
-        "id": "tidal_shells",
-        "itemId": "sea_shell",
-        "minQuantity": 1,
-        "maxQuantity": 2,
-        "seasons": ["Spring", "Summer", "Autumn"],
-        "biomes": ["coast"],
-        "weight": 0.8,
-        "gathersPerSpot": 4,
-        "skill": "foraging",
-        "skillXp": 2.5
+        "pred": "works_at",
+        "a": "P-0005",
+        "b": "Bakery"
       },
       {
-        "id": "storm_driftwood",
-        "itemId": "driftwood_bundle",
-        "minQuantity": 1,
-        "maxQuantity": 1,
-        "seasons": ["Autumn", "Winter"],
-        "weather": ["Rain", "Storm"],
-        "biomes": ["coast"],
-        "weight": 0.7,
-        "gathersPerSpot": 2,
-        "skill": "foraging",
-        "skillXp": 3.0
-      }
-    ]
-  },
-  "mining": {
-    "enabled": true,
-    "respawnHours": 10.0,
-    "maxActiveNodes": 12,
-    "ores": [
-      {
-        "id": "surface_copper",
-        "itemId": "copper_ore",
-        "minQuantity": 1,
-        "maxQuantity": 2,
-        "seasons": ["Spring", "Summer", "Autumn"],
-        "weather": ["Clear", "Cloudy", "Rain"],
-        "biomes": ["mountain", "forest"],
-        "weight": 1.0,
-        "hitsPerNode": 3,
-        "requiredToolId": "",
-        "requiredToolTier": 0,
-        "skill": "mining",
-        "skillXp": 5.0
+        "pred": "works_at",
+        "a": "P-0006",
+        "b": "Bakery"
       },
       {
-        "id": "deep_iron",
-        "itemId": "iron_ore",
-        "minQuantity": 1,
-        "maxQuantity": 2,
-        "seasons": ["Autumn", "Winter"],
-        "weather": ["Clear", "Cloudy", "Storm"],
-        "biomes": ["mountain", "cavern"],
-        "weight": 0.75,
-        "hitsPerNode": 4,
-        "requiredToolId": "",
-        "requiredToolTier": 1,
-        "skill": "mining",
-        "skillXp": 6.0
+        "pred": "works_at",
+        "a": "P-0007",
+        "b": "MayorHouse"
       },
       {
-        "id": "coal_seam",
-        "itemId": "coal_chunk",
-        "minQuantity": 1,
-        "maxQuantity": 3,
-        "seasons": ["Spring", "Summer", "Autumn", "Winter"],
-        "weather": ["Clear", "Cloudy", "Rain", "Storm"],
-        "biomes": ["mountain", "cavern"],
-        "weight": 0.5,
-        "hitsPerNode": 2,
-        "requiredToolId": "",
-        "requiredToolTier": 1,
-        "skill": "mining",
-        "skillXp": 4.5
-      }
-    ],
-    "layers": [
-      {
-        "id": "surface",
-        "oreIds": ["surface_copper", "coal_seam"],
-        "biomes": ["forest", "mountain"]
+        "pred": "works_at",
+        "a": "P-0008",
+        "b": "MayorHouse"
       },
       {
-        "id": "deep",
-        "oreIds": ["deep_iron", "coal_seam"],
-        "biomes": ["mountain", "cavern"]
-      }
-    ],
-    "nodes": [
-      {
-        "id": "mine_north_entrance",
-        "type": "mine_node",
-        "tags": ["mine_node", "resource", "service_point"],
-        "x": 612,
-        "y": 198,
-        "layer": "surface",
-        "biomes": ["mountain"]
+        "pred": "works_at",
+        "a": "P-0009",
+        "b": "GeneralStore"
       },
       {
-        "id": "mine_central_chamber",
-        "type": "mine_node",
-        "tags": ["mine_node", "resource", "service_point"],
-        "x": 618,
-        "y": 204,
-        "layer": "deep",
-        "biomes": ["mountain", "cavern"]
+        "pred": "works_at",
+        "a": "P-0010",
+        "b": "GeneralStore"
       },
       {
-        "id": "mine_western_shaft",
-        "type": "mine_node",
-        "tags": ["mine_node", "resource", "service_point"],
-        "x": 604,
-        "y": 210,
-        "layer": "surface",
-        "biomes": ["forest", "mountain"]
-      }
-    ]
-  },
-  "schedules": {
-    "path": "schedules.json"
-  },
-  "events": {
-    "path": "events.json"
-  },
-  "dialogue": {
-    "path": "dialogue.json"
-  },
-  "quests": {
-    "path": "quests.json"
-  },
-  "weather": {
-    "enabled": true,
-    "defaultState": "Clear",
-    "dawnHour": 6,
-    "gustIntervalHours": 2,
-    "states": [
-      {
-        "id": "Clear",
-        "displayName": "Clear Skies",
-        "autoWaterCrops": false,
-        "growthPause": false,
-        "cancelOutdoorShifts": false,
-        "pathCostMultiplier": 1.0,
-        "weight": 5,
-        "seasonWeights": {
-          "Spring": 1.0,
-          "Summer": 1.2,
-          "Autumn": 0.9,
-          "Winter": 0.8
-        },
-        "transitions": [
-          {"to": "Clear", "weight": 4},
-          {"to": "Cloudy", "weight": 3},
-          {"to": "Rain", "weight": 1}
-        ],
-        "gustStrengthMin": 0,
-        "gustStrengthMax": 5
+        "pred": "works_at",
+        "a": "P-0013",
+        "b": "FarmField"
       },
       {
-        "id": "Cloudy",
-        "displayName": "Cloudy",
-        "autoWaterCrops": false,
-        "growthPause": false,
-        "cancelOutdoorShifts": false,
-        "pathCostMultiplier": 1.05,
-        "weight": 3,
-        "seasonWeights": {
-          "Spring": 1.0,
-          "Summer": 0.9,
-          "Autumn": 1.1,
-          "Winter": 1.0
-        },
-        "transitions": [
-          {"to": "Clear", "weight": 3},
-          {"to": "Cloudy", "weight": 3},
-          {"to": "Rain", "weight": 2}
-        ],
-        "gustStrengthMin": 3,
-        "gustStrengthMax": 10
+        "pred": "works_at",
+        "a": "P-0014",
+        "b": "FarmField"
       },
       {
-        "id": "Rain",
-        "displayName": "Rain",
-        "autoWaterCrops": true,
-        "growthPause": false,
-        "cancelOutdoorShifts": false,
-        "pathCostMultiplier": 1.1,
-        "weight": 2,
-        "seasonWeights": {
-          "Spring": 1.1,
-          "Summer": 0.8,
-          "Autumn": 1.2,
-          "Winter": 0.7
-        },
-        "transitions": [
-          {"to": "Clear", "weight": 2},
-          {"to": "Cloudy", "weight": 3},
-          {"to": "Storm", "weight": 1}
-        ],
-        "gustStrengthMin": 5,
-        "gustStrengthMax": 15
+        "pred": "works_at",
+        "a": "P-0015",
+        "b": "FarmField"
       },
       {
-        "id": "Storm",
-        "displayName": "Storm",
-        "autoWaterCrops": true,
-        "growthPause": true,
-        "cancelOutdoorShifts": true,
-        "pathCostMultiplier": 1.4,
-        "weight": 1,
-        "seasonWeights": {
-          "Spring": 0.8,
-          "Summer": 0.6,
-          "Autumn": 0.9,
-          "Winter": 0.5
-        },
-        "transitions": [
-          {"to": "Cloudy", "weight": 3},
-          {"to": "Rain", "weight": 2}
-        ],
-        "gustStrengthMin": 15,
-        "gustStrengthMax": 35
-      }
-    ]
-  },
-  "persistence": {
-    "directory": "saves",
-    "saveSlot": "demo",
-    "autosaveMinutes": 10
-  },
-  "social": {
-    "enabled": true,
-    "relationshipTypes": [
-      {
-        "id": "friendship",
-        "symmetric": true,
-        "minValue": -1.0,
-        "maxValue": 1.0,
-        "defaultValue": 0.0,
-        "description": "Affinity/hostility; higher=likes more"
-      }
-    ],
-    "seeds": [
-      {
-        "from": "P-0001",
-        "to": "P-0100",
-        "type": "friendship",
-        "value": 0.85,
-        "notes": "HeadTeacher and loyal dog Miso"
+        "pred": "works_at",
+        "a": "P-0016",
+        "b": "FarmField"
       },
       {
-        "from": "P-0100",
-        "to": "P-0001",
-        "type": "friendship",
-        "value": 0.95,
-        "notes": "Miso adores Iris"
+        "pred": "works_at",
+        "a": "P-0017",
+        "b": "FarmField"
       },
       {
-        "from": "P-0008",
-        "to": "P-0101",
-        "type": "friendship",
-        "value": 0.8,
-        "notes": "Thalia cares for Juniper the cat"
+        "pred": "works_at",
+        "a": "P-0018",
+        "b": "FarmField"
       },
       {
-        "from": "P-0101",
-        "to": "P-0008",
-        "type": "friendship",
-        "value": 0.9,
-        "notes": "Juniper is fond of Thalia"
+        "pred": "works_at",
+        "a": "P-0019",
+        "b": "FarmField"
       },
       {
-        "from": "P-0013",
-        "to": "P-0102",
-        "type": "friendship",
-        "value": 0.75,
-        "notes": "Farmer Miles tends Betsy the cow"
+        "pred": "works_at",
+        "a": "P-0020",
+        "b": "FarmField"
       },
       {
-        "from": "P-0102",
-        "to": "P-0013",
-        "type": "friendship",
-        "value": 0.7,
-        "notes": "Betsy trusts Miles"
+        "pred": "works_at",
+        "a": "P-0021",
+        "b": "FarmField"
       },
       {
-        "from": "P-0016",
-        "to": "P-0103",
-        "type": "friendship",
-        "value": 0.7,
-        "notes": "Farmer Miles Davies looks after Cloud the sheep"
+        "pred": "works_at",
+        "a": "P-0022",
+        "b": "FarmField"
       },
       {
-        "from": "P-0103",
-        "to": "P-0016",
-        "type": "friendship",
-        "value": 0.65,
-        "notes": "Cloud follows Miles Davies"
+        "pred": "works_at",
+        "a": "P-0023",
+        "b": "FarmField"
       },
       {
-        "from": "P-0015",
-        "to": "P-0104",
-        "type": "friendship",
-        "value": 0.7,
-        "notes": "Farmhand Wes looks after Nugget the chicken"
+        "pred": "works_at",
+        "a": "P-0024",
+        "b": "FarmField"
       },
       {
-        "from": "P-0104",
-        "to": "P-0015",
-        "type": "friendship",
-        "value": 0.8,
-        "notes": "Nugget sticks close to Wes"
-      }
-    ]
-  },
-  "actors": {
-    "count": 41,
-    "type": "human",
-    "tags": [
-      "actor",
-      "human"
-    ],
-    "attributes": {
-      "loneliness": {
-        "min": 0.25,
-        "max": 0.85
-      },
-      "fatigue": {
-        "min": 0.3,
-        "max": 0.6
-      },
-      "aggression": {
-        "min": 0.05,
-        "max": 0.2
-      },
-      "hunger": {
-        "min": 0.25,
-        "max": 0.7
-      },
-      "ingredients": {
-        "value": 0
-      },
-      "health": {
-        "value": 1.0
-      }
-    },
-    "inventory": {
-      "slots": 12,
-      "stackSize": 20,
-      "start": [
-        {"id": "basic_pickaxe", "quantity": 1},
-        {"id": "basic_fishing_rod", "quantity": 1}
-      ]
-    },
-    "currency": 25
-  },
-  "player": {
-    "id": "player",
-    "tags": [
-      "actor",
-      "villager",
-      "player"
-    ],
-    "spawn": {
-      "id": "Bakery"
-    },
-    "inventory": {
-      "slots": 18,
-      "stackSize": 30,
-      "start": [
-        {"id": "basic_pickaxe", "quantity": 1},
-        {"id": "basic_fishing_rod", "quantity": 1}
-      ]
-    },
-    "currency": 50,
-    "attributes": {
-      "hunger": 0.2,
-      "fatigue": 0.1,
-      "loneliness": 0.3
-    },
-    "allowAiFallback": false,
-    "autoEvaluateManualPlans": false
-  },
-  "observer": {
-    "cameraPawn": "player",
-    "showOnlySelectedPawn": false
-  },
-  "simulation": {
-    "durationGameDays": 5.0,
-    "actorHostSeed": 8675309,
-    "priorityJitter": 0.05,
-    "actorLoopFrequencyHz": 2.0,
-    "perPawnLoggingEnabled": false
-  },
-  "time": {
-    "dayLengthSeconds": 600,
-    "worldHoursPerDay": 24,
-    "minutesPerHour": 60,
-    "secondsPerMinute": 60,
-    "daysPerMonth": 30,
-    "seasonLengthDays": 90,
-    "seasons": [
-      "Spring",
-      "Summer",
-      "Autumn",
-      "Winter"
-    ],
-    "startYear": 1,
-    "startDayOfYear": 1,
-    "startTimeOfDayHours": 6
-  },
-  "needs": {
-    "enabled": true,
-    "needs": [
-      {
-        "id": "fatigue_daily",
-        "attribute": "fatigue",
-        "changePerTrigger": 0.30,
-        "triggersPerDay": 2,
-        "clamp01": true,
-        "targetTags": [
-          "actor"
-        ]
+        "pred": "works_at",
+        "a": "P-0025",
+        "b": "FarmField"
       },
       {
-        "id": "hunger_daily",
-        "attribute": "hunger",
-        "changePerTrigger": 0.30,
-        "triggersPerDay": 2,
-        "clamp01": true,
-        "targetTags": [
-          "actor"
-        ]
+        "pred": "works_at",
+        "a": "P-0026",
+        "b": "FarmField"
+      },
+      {
+        "pred": "works_at",
+        "a": "P-0027",
+        "b": "FarmField"
+      },
+      {
+        "pred": "works_at",
+        "a": "P-0028",
+        "b": "FarmField"
+      },
+      {
+        "pred": "works_at",
+        "a": "P-0029",
+        "b": "FarmField"
+      },
+      {
+        "pred": "works_at",
+        "a": "P-0030",
+        "b": "FarmField"
+      },
+      {
+        "pred": "works_at",
+        "a": "P-0031",
+        "b": "FarmField"
+      },
+      {
+        "pred": "works_at",
+        "a": "P-0032",
+        "b": "FarmField"
+      },
+      {
+        "pred": "works_at",
+        "a": "P-0033",
+        "b": "FarmField"
+      },
+      {
+        "pred": "works_at",
+        "a": "P-0034",
+        "b": "FarmField"
+      },
+      {
+        "pred": "works_at",
+        "a": "P-0035",
+        "b": "FarmField"
+      },
+      {
+        "pred": "works_at",
+        "a": "P-0036",
+        "b": "FarmField"
+      },
+      {
+        "pred": "tag",
+        "a": "P-0102",
+        "b": "animal"
+      },
+      {
+        "pred": "tag",
+        "a": "P-0102",
+        "b": "livestock"
+      },
+      {
+        "pred": "tag",
+        "a": "P-0103",
+        "b": "animal"
+      },
+      {
+        "pred": "tag",
+        "a": "P-0103",
+        "b": "livestock"
+      },
+      {
+        "pred": "tag",
+        "a": "P-0104",
+        "b": "animal"
+      },
+      {
+        "pred": "tag",
+        "a": "P-0104",
+        "b": "livestock"
       }
     ]
   }

--- a/Assets/Data/demo.simulation.json
+++ b/Assets/Data/demo.simulation.json
@@ -1,0 +1,7 @@
+{
+  "durationGameDays": 5.0,
+  "actorHostSeed": 8675309,
+  "priorityJitter": 0.05,
+  "actorLoopFrequencyHz": 2.0,
+  "perPawnLoggingEnabled": false
+}

--- a/Assets/Data/demo.simulation.json.meta
+++ b/Assets/Data/demo.simulation.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 957598c654584820ba7b9151fcace1df
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Data/demo.social.json
+++ b/Assets/Data/demo.social.json
@@ -1,0 +1,85 @@
+{
+  "enabled": true,
+  "relationshipTypes": [
+    {
+      "id": "friendship",
+      "symmetric": true,
+      "minValue": -1.0,
+      "maxValue": 1.0,
+      "defaultValue": 0.0,
+      "description": "Affinity/hostility; higher=likes more"
+    }
+  ],
+  "seeds": [
+    {
+      "from": "P-0001",
+      "to": "P-0100",
+      "type": "friendship",
+      "value": 0.85,
+      "notes": "HeadTeacher and loyal dog Miso"
+    },
+    {
+      "from": "P-0100",
+      "to": "P-0001",
+      "type": "friendship",
+      "value": 0.95,
+      "notes": "Miso adores Iris"
+    },
+    {
+      "from": "P-0008",
+      "to": "P-0101",
+      "type": "friendship",
+      "value": 0.8,
+      "notes": "Thalia cares for Juniper the cat"
+    },
+    {
+      "from": "P-0101",
+      "to": "P-0008",
+      "type": "friendship",
+      "value": 0.9,
+      "notes": "Juniper is fond of Thalia"
+    },
+    {
+      "from": "P-0013",
+      "to": "P-0102",
+      "type": "friendship",
+      "value": 0.75,
+      "notes": "Farmer Miles tends Betsy the cow"
+    },
+    {
+      "from": "P-0102",
+      "to": "P-0013",
+      "type": "friendship",
+      "value": 0.7,
+      "notes": "Betsy trusts Miles"
+    },
+    {
+      "from": "P-0016",
+      "to": "P-0103",
+      "type": "friendship",
+      "value": 0.7,
+      "notes": "Farmer Miles Davies looks after Cloud the sheep"
+    },
+    {
+      "from": "P-0103",
+      "to": "P-0016",
+      "type": "friendship",
+      "value": 0.65,
+      "notes": "Cloud follows Miles Davies"
+    },
+    {
+      "from": "P-0015",
+      "to": "P-0104",
+      "type": "friendship",
+      "value": 0.7,
+      "notes": "Farmhand Wes looks after Nugget the chicken"
+    },
+    {
+      "from": "P-0104",
+      "to": "P-0015",
+      "type": "friendship",
+      "value": 0.8,
+      "notes": "Nugget sticks close to Wes"
+    }
+  ]
+}

--- a/Assets/Data/demo.social.json.meta
+++ b/Assets/Data/demo.social.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9fb37a318b394f5cb50992b1d15dc8d8
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Data/demo.time.json
+++ b/Assets/Data/demo.time.json
@@ -1,0 +1,17 @@
+{
+  "dayLengthSeconds": 600,
+  "worldHoursPerDay": 24,
+  "minutesPerHour": 60,
+  "secondsPerMinute": 60,
+  "daysPerMonth": 30,
+  "seasonLengthDays": 90,
+  "seasons": [
+    "Spring",
+    "Summer",
+    "Autumn",
+    "Winter"
+  ],
+  "startYear": 1,
+  "startDayOfYear": 1,
+  "startTimeOfDayHours": 6
+}

--- a/Assets/Data/demo.time.json.meta
+++ b/Assets/Data/demo.time.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 86aea0286d95434a8b4154a152925464
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Data/demo.weather.json
+++ b/Assets/Data/demo.weather.json
@@ -1,0 +1,128 @@
+{
+  "enabled": true,
+  "defaultState": "Clear",
+  "dawnHour": 6,
+  "gustIntervalHours": 2,
+  "states": [
+    {
+      "id": "Clear",
+      "displayName": "Clear Skies",
+      "autoWaterCrops": false,
+      "growthPause": false,
+      "cancelOutdoorShifts": false,
+      "pathCostMultiplier": 1.0,
+      "weight": 5,
+      "seasonWeights": {
+        "Spring": 1.0,
+        "Summer": 1.2,
+        "Autumn": 0.9,
+        "Winter": 0.8
+      },
+      "transitions": [
+        {
+          "to": "Clear",
+          "weight": 4
+        },
+        {
+          "to": "Cloudy",
+          "weight": 3
+        },
+        {
+          "to": "Rain",
+          "weight": 1
+        }
+      ],
+      "gustStrengthMin": 0,
+      "gustStrengthMax": 5
+    },
+    {
+      "id": "Cloudy",
+      "displayName": "Cloudy",
+      "autoWaterCrops": false,
+      "growthPause": false,
+      "cancelOutdoorShifts": false,
+      "pathCostMultiplier": 1.05,
+      "weight": 3,
+      "seasonWeights": {
+        "Spring": 1.0,
+        "Summer": 0.9,
+        "Autumn": 1.1,
+        "Winter": 1.0
+      },
+      "transitions": [
+        {
+          "to": "Clear",
+          "weight": 3
+        },
+        {
+          "to": "Cloudy",
+          "weight": 3
+        },
+        {
+          "to": "Rain",
+          "weight": 2
+        }
+      ],
+      "gustStrengthMin": 3,
+      "gustStrengthMax": 10
+    },
+    {
+      "id": "Rain",
+      "displayName": "Rain",
+      "autoWaterCrops": true,
+      "growthPause": false,
+      "cancelOutdoorShifts": false,
+      "pathCostMultiplier": 1.1,
+      "weight": 2,
+      "seasonWeights": {
+        "Spring": 1.1,
+        "Summer": 0.8,
+        "Autumn": 1.2,
+        "Winter": 0.7
+      },
+      "transitions": [
+        {
+          "to": "Clear",
+          "weight": 2
+        },
+        {
+          "to": "Cloudy",
+          "weight": 3
+        },
+        {
+          "to": "Storm",
+          "weight": 1
+        }
+      ],
+      "gustStrengthMin": 5,
+      "gustStrengthMax": 15
+    },
+    {
+      "id": "Storm",
+      "displayName": "Storm",
+      "autoWaterCrops": true,
+      "growthPause": true,
+      "cancelOutdoorShifts": true,
+      "pathCostMultiplier": 1.4,
+      "weight": 1,
+      "seasonWeights": {
+        "Spring": 0.8,
+        "Summer": 0.6,
+        "Autumn": 0.9,
+        "Winter": 0.5
+      },
+      "transitions": [
+        {
+          "to": "Cloudy",
+          "weight": 3
+        },
+        {
+          "to": "Rain",
+          "weight": 2
+        }
+      ],
+      "gustStrengthMin": 15,
+      "gustStrengthMax": 35
+    }
+  ]
+}

--- a/Assets/Data/demo.weather.json.meta
+++ b/Assets/Data/demo.weather.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0c88ac8864dd48c3be571d17675798d5
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- restore the demo configuration content removed from `demo.settings.json` into dedicated JSON files under `Assets/Data`
- add matching Unity `.meta` descriptors for each new data file so the editor can load them

## Testing
- not run (data-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e4904d5bc083229faf396abad8f211