### PR TITLE
Ensure runtime panel settings include default theme

### DIFF
--- a/Assets/Scripts/Sim/World/GameServices.cs
+++ b/Assets/Scripts/Sim/World/GameServices.cs
@@ -67,16 +67,19 @@ namespace Sim.World
             _cached = Resources.Load<PanelSettings>("PanelSettings/DefaultPanelSettings");
             if (_cached == null)
             {
-                _cached = ScriptableObject.CreateInstance<PanelSettings>();
+                _cached = ScriptableObject.CreateInstance<RuntimePanelSettings>();
                 _cached.name = "RuntimePanelSettings";
             }
 
-            EnsureThemeAssigned(_cached);
+            PanelSettingsThemeUtility.EnsureThemeAssigned(_cached);
 
             return _cached;
         }
+    }
 
-        private static void EnsureThemeAssigned(PanelSettings settings)
+    internal static class PanelSettingsThemeUtility
+    {
+        public static void EnsureThemeAssigned(PanelSettings settings)
         {
             if (settings == null)
                 return;

--- a/Assets/Scripts/Sim/World/RuntimePanelSettings.cs
+++ b/Assets/Scripts/Sim/World/RuntimePanelSettings.cs
@@ -1,0 +1,25 @@
+// Assets/Scripts/Sim/World/RuntimePanelSettings.cs
+// C# 8.0
+using System.Reflection;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Sim.World
+{
+    /// <summary>
+    /// PanelSettings instance that guarantees a theme is assigned before the base
+    /// PanelSettings initialization runs. This suppresses warnings that are logged when
+    /// Unity creates a theme-less PanelSettings via ScriptableObject.CreateInstance.
+    /// </summary>
+    public sealed class RuntimePanelSettings : PanelSettings
+    {
+        protected void OnEnable()
+        {
+            PanelSettingsThemeUtility.EnsureThemeAssigned(this);
+
+            var onEnable = typeof(PanelSettings).GetMethod("OnEnable", BindingFlags.Instance | BindingFlags.NonPublic);
+            onEnable?.Invoke(this, null);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- ensure runtime-created panel settings instances apply the default theme before base initialization
- share theme assignment logic so resources-loaded panel settings also retain the default theme

## Testing
- not run (Unity editor)


------
https://chatgpt.com/codex/tasks/task_e_68e496220ef083229b1e3c5bf0641887