### PR TITLE
Fix RuntimePanelSettings initialization

### DIFF
--- a/Assets/Scripts/Sim/World/RuntimePanelSettings.cs
+++ b/Assets/Scripts/Sim/World/RuntimePanelSettings.cs
@@ -1,6 +1,5 @@
 // Assets/Scripts/Sim/World/RuntimePanelSettings.cs
 // C# 8.0
-using System.Reflection;
 using UnityEngine;
 using UnityEngine.UIElements;
 
@@ -13,12 +12,10 @@ namespace Sim.World
     /// </summary>
     public sealed class RuntimePanelSettings : PanelSettings
     {
-        protected void OnEnable()
+        protected override void OnEnable()
         {
             PanelSettingsThemeUtility.EnsureThemeAssigned(this);
-
-            var onEnable = typeof(PanelSettings).GetMethod("OnEnable", BindingFlags.Instance | BindingFlags.NonPublic);
-            onEnable?.Invoke(this, null);
+            base.OnEnable();
         }
     }
 }


### PR DESCRIPTION
## Summary
- override OnEnable in RuntimePanelSettings to ensure the base implementation runs without reflection
- keep assigning the theme before deferring to the PanelSettings OnEnable logic

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68e4978639fc8322849b0da6b4eaad0c