### PR TITLE
Fix RuntimePanelSettings OnEnable override

### DIFF
--- a/Assets/Scripts/Sim/World/RuntimePanelSettings.cs
+++ b/Assets/Scripts/Sim/World/RuntimePanelSettings.cs
@@ -1,5 +1,6 @@
 // Assets/Scripts/Sim/World/RuntimePanelSettings.cs
 // C# 8.0
+using System.Reflection;
 using UnityEngine;
 using UnityEngine.UIElements;
 
@@ -12,10 +13,13 @@ namespace Sim.World
     /// </summary>
     public sealed class RuntimePanelSettings : PanelSettings
     {
-        protected override void OnEnable()
+        private static readonly MethodInfo s_OnEnableMethod = typeof(PanelSettings)
+            .GetMethod("OnEnable", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        protected void OnEnable()
         {
             PanelSettingsThemeUtility.EnsureThemeAssigned(this);
-            base.OnEnable();
+            s_OnEnableMethod?.Invoke(this, null);
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace the overridden OnEnable method with a regular handler so it is compatible with the current PanelSettings API
- ensure the original PanelSettings.OnEnable logic still runs via reflection while preserving the theme assignment step

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4986c972c83229d876d45922cfdaf