### PR TITLE
Adjust runtime panel settings creation for Unity API change

### DIFF
--- a/Assets/Scripts/Sim/World/GameServices.cs
+++ b/Assets/Scripts/Sim/World/GameServices.cs
@@ -67,7 +67,7 @@ namespace Sim.World
             _cached = Resources.Load<PanelSettings>("PanelSettings/DefaultPanelSettings");
             if (_cached == null)
             {
-                _cached = ScriptableObject.CreateInstance<RuntimePanelSettings>();
+                _cached = RuntimePanelSettings.CreateInstance();
                 _cached.name = "RuntimePanelSettings";
             }
 

--- a/Assets/Scripts/Sim/World/RuntimePanelSettings.cs
+++ b/Assets/Scripts/Sim/World/RuntimePanelSettings.cs
@@ -7,19 +7,24 @@ using UnityEngine.UIElements;
 namespace Sim.World
 {
     /// <summary>
-    /// PanelSettings instance that guarantees a theme is assigned before the base
-    /// PanelSettings initialization runs. This suppresses warnings that are logged when
-    /// Unity creates a theme-less PanelSettings via ScriptableObject.CreateInstance.
+    /// Utility for creating <see cref="PanelSettings"/> instances that have a theme
+    /// assigned immediately after creation. Unity no longer allows inheriting from
+    /// <see cref="PanelSettings"/>, so we emulate the previous behaviour by assigning the
+    /// theme and re-invoking the internal <c>OnEnable</c> method after instantiation.
     /// </summary>
-    public sealed class RuntimePanelSettings : PanelSettings
+    public static class RuntimePanelSettings
     {
         private static readonly MethodInfo s_OnEnableMethod = typeof(PanelSettings)
             .GetMethod("OnEnable", BindingFlags.Instance | BindingFlags.NonPublic);
 
-        protected void OnEnable()
+        public static PanelSettings CreateInstance()
         {
-            PanelSettingsThemeUtility.EnsureThemeAssigned(this);
-            s_OnEnableMethod?.Invoke(this, null);
+            var settings = ScriptableObject.CreateInstance<PanelSettings>();
+
+            PanelSettingsThemeUtility.EnsureThemeAssigned(settings);
+            s_OnEnableMethod?.Invoke(settings, null);
+
+            return settings;
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace the RuntimePanelSettings ScriptableObject subclass with a static factory that instantiates PanelSettings directly
- ensure a theme is still applied and the internal OnEnable method reruns after creation
- update the runtime panel settings provider to use the new factory

## Testing
- not run (Unity editor only)


------
https://chatgpt.com/codex/tasks/task_e_68e49902c34c8322b637bb1128e9a556