### PR TITLE
Fix tile orientation

### DIFF
--- a/Assets/Scripts/Sim/World/MapLoader.cs
+++ b/Assets/Scripts/Sim/World/MapLoader.cs
@@ -149,7 +149,7 @@ namespace Sim.World
                     tile.transform.SetParent(parent, false);
                     tile.transform.localPosition = new Vector3(x * tileSize, y * tileSize, 0f);
                     tile.transform.localScale = Vector3.one * tileSize;
-                    tile.transform.localRotation = Quaternion.Euler(0f, 180f, 0f);
+                    tile.transform.localRotation = Quaternion.identity;
 
                     var collider = tile.GetComponent<Collider>();
                     if (collider != null)


### PR DESCRIPTION
## Summary
- stop rotating generated world tiles by 180 degrees so they face the correct direction

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e49ca7e1a88322990ad00723430545