### PR TITLE
Use item icon paths for inventory sprites

### DIFF
--- a/Assets/Scripts/Sim/UI/Inventory/InventoryGridPresenter.cs
+++ b/Assets/Scripts/Sim/UI/Inventory/InventoryGridPresenter.cs
@@ -59,7 +59,11 @@ namespace Sim.World
                 if (i < _inventory.Items.Count)
                 {
                     var stack = _inventory.Items[i];
-                    var sprite = SpriteResolver.LoadSpriteFromResources("Items/" + stack.ItemId);
+                    var iconPath = stack?.Item?.IconPath;
+                    var spriteKey = string.IsNullOrWhiteSpace(iconPath)
+                        ? "Items/" + stack.ItemId
+                        : iconPath;
+                    var sprite = SpriteResolver.LoadSpriteFromResources(spriteKey);
                     var img = new Image();
                     img.sprite = sprite;
                     img.scaleMode = ScaleMode.ScaleToFit;


### PR DESCRIPTION
## Summary
- load inventory slot sprites using the item definition's icon path when available
- fall back to the legacy item-id based lookup to preserve compatibility with existing assets

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4ac6df4888322873acaf3a38a6954