### PR TITLE
Switch log writing to Unity debug console

### DIFF
--- a/Assets/Scripts/Sim/Logging/Log.cs
+++ b/Assets/Scripts/Sim/Logging/Log.cs
@@ -1,31 +1,29 @@
 // Assets/Scripts/Sim/Logging/Log.cs
 // C# 8.0
 using System;
-using System.IO;
 using UnityEngine;
 
 namespace Sim.Logging
 {
     public static class Log
     {
-        private const string WorldLogFileName = "world.log";
-        private static string _worldLogPath = string.Empty;
-        public static string WorldLogPath => _worldLogPath;
+        private const string WorldLogPrefix = "[World]";
+        private const string PawnLogPrefix = "[Pawn]";
+        private static bool _initialized;
 
         public static void InitLogs()
         {
-            var logsDir = Path.Combine(Application.dataPath, "..", "logs");
-            Directory.CreateDirectory(logsDir);
-            Directory.CreateDirectory(Path.Combine(logsDir, "pawn"));
+            if (_initialized) return;
 
-            _worldLogPath = Path.GetFullPath(Path.Combine(logsDir, WorldLogFileName));
-            File.AppendAllText(_worldLogPath, $"[{DateTime.Now:O}] World log initialized.{Environment.NewLine}");
+            _initialized = true;
+            Debug.Log($"{WorldLogPrefix} Logging initialized.");
         }
 
         public static void World(string message)
         {
-            if (string.IsNullOrEmpty(_worldLogPath)) InitLogs();
-            File.AppendAllText(_worldLogPath, $"[{DateTime.Now:O}] {message}{Environment.NewLine}");
+            if (!_initialized) InitLogs();
+
+            Debug.Log($"{WorldLogPrefix} {message}");
         }
 
         public static void Pawn(string pawnId, string message)
@@ -33,10 +31,7 @@ namespace Sim.Logging
             if (string.IsNullOrWhiteSpace(pawnId))
                 throw new ArgumentException("Pawn id is required for pawn logs.", nameof(pawnId));
 
-            var logsDir = Path.Combine(Application.dataPath, "..", "logs", "pawn");
-            Directory.CreateDirectory(logsDir);
-            var path = Path.Combine(logsDir, $"{pawnId}.log");
-            File.AppendAllText(path, $"[{DateTime.Now:O}] {message}{Environment.NewLine}");
+            Debug.Log($"{PawnLogPrefix} [{pawnId}] {message}");
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove file-system based logging paths and initialization side effects
- route world and pawn log messages to the Unity debug console with consistent prefixes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e52f7e1c408322a579449cca9965a6