### PR TITLE
Optimize grid pathfinding to reduce load delays

### DIFF
--- a/Assets/Scripts/Sim/World/GridPathfinder.cs
+++ b/Assets/Scripts/Sim/World/GridPathfinder.cs
@@ -26,19 +26,20 @@ namespace Sim.World
             if (!bounds.Contains(start) || !bounds.Contains(goal))
                 return path;
 
-            var open = new List<Node>();
+            var open = new MinHeap<Node>();
             var lookup = new Dictionary<Vector2Int, Node>();
             var closed = new HashSet<Vector2Int>();
 
             var startNode = new Node(start, 0, Heuristic(start, goal), null);
-            open.Add(startNode);
+            open.Push(startNode);
             lookup[start] = startNode;
 
             while (open.Count > 0)
             {
-                open.Sort((a, b) => a.F.CompareTo(b.F));
-                var current = open[0];
-                open.RemoveAt(0);
+                var current = open.Pop();
+
+                if (!lookup.TryGetValue(current.Position, out var latest) || !ReferenceEquals(current, latest))
+                    continue;
 
                 if (current.Position == goal)
                     return Reconstruct(current);
@@ -56,20 +57,12 @@ namespace Sim.World
                         continue;
 
                     var gScore = current.G + 1;
-                    if (!lookup.TryGetValue(nextPos, out var neighbor))
-                    {
-                        neighbor = new Node(nextPos, gScore, Heuristic(nextPos, goal), current);
-                        lookup[nextPos] = neighbor;
-                        open.Add(neighbor);
-                    }
-                    else if (gScore < neighbor.G)
-                    {
-                        neighbor.G = gScore;
-                        neighbor.Parent = current;
-                        neighbor.UpdateF();
-                        if (!open.Contains(neighbor))
-                            open.Add(neighbor);
-                    }
+                    if (lookup.TryGetValue(nextPos, out var existing) && gScore >= existing.G)
+                        continue;
+
+                    var neighbor = new Node(nextPos, gScore, Heuristic(nextPos, goal), current);
+                    lookup[nextPos] = neighbor;
+                    open.Push(neighbor);
                 }
             }
 
@@ -95,12 +88,12 @@ namespace Sim.World
             return Mathf.Abs(a.x - b.x) + Mathf.Abs(a.y - b.y);
         }
 
-        private sealed class Node
+        private sealed class Node : IComparable<Node>
         {
             public Vector2Int Position { get; }
-            public int G { get; set; }
+            public int G { get; }
             public int H { get; }
-            public int F { get; private set; }
+            public int F { get; }
             public Node Parent { get; set; }
 
             public Node(Vector2Int position, int g, int h, Node parent)
@@ -112,9 +105,105 @@ namespace Sim.World
                 F = g + h;
             }
 
-            public void UpdateF()
+            public int CompareTo(Node other)
             {
-                F = G + H;
+                if (other == null)
+                    return -1;
+
+                var compare = F.CompareTo(other.F);
+                if (compare != 0)
+                    return compare;
+
+                compare = H.CompareTo(other.H);
+                if (compare != 0)
+                    return compare;
+
+                compare = G.CompareTo(other.G);
+                if (compare != 0)
+                    return compare;
+
+                compare = Position.x.CompareTo(other.Position.x);
+                if (compare != 0)
+                    return compare;
+
+                return Position.y.CompareTo(other.Position.y);
+            }
+        }
+
+        private sealed class MinHeap<T> where T : IComparable<T>
+        {
+            private readonly List<T> _items = new List<T>();
+
+            public int Count => _items.Count;
+
+            public void Push(T item)
+            {
+                if (item == null)
+                    throw new ArgumentNullException(nameof(item));
+
+                _items.Add(item);
+                BubbleUp(_items.Count - 1);
+            }
+
+            public T Pop()
+            {
+                if (_items.Count == 0)
+                    throw new InvalidOperationException("Cannot remove item from an empty heap.");
+
+                var root = _items[0];
+                var lastIndex = _items.Count - 1;
+                var last = _items[lastIndex];
+                _items.RemoveAt(lastIndex);
+
+                if (_items.Count > 0)
+                {
+                    _items[0] = last;
+                    BubbleDown(0);
+                }
+
+                return root;
+            }
+
+            private void BubbleUp(int index)
+            {
+                while (index > 0)
+                {
+                    var parent = (index - 1) / 2;
+                    if (_items[index].CompareTo(_items[parent]) >= 0)
+                        break;
+
+                    Swap(index, parent);
+                    index = parent;
+                }
+            }
+
+            private void BubbleDown(int index)
+            {
+                while (true)
+                {
+                    var left = index * 2 + 1;
+                    var right = left + 1;
+                    var smallest = index;
+
+                    if (left < _items.Count && _items[left].CompareTo(_items[smallest]) < 0)
+                        smallest = left;
+
+                    if (right < _items.Count && _items[right].CompareTo(_items[smallest]) < 0)
+                        smallest = right;
+
+                    if (smallest == index)
+                        break;
+
+                    Swap(index, smallest);
+                    index = smallest;
+                }
+            }
+
+            private void Swap(int a, int b)
+            {
+                var temp = _items[a];
+                _items[a] = _items[b];
+                _items[b] = temp;
             }
         }
     }


### PR DESCRIPTION
## Summary
- replace the grid pathfinder's sorted list with a binary min-heap to avoid repeated list sorting
- skip outdated nodes retrieved from the heap to ensure only the latest distances are processed

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68e536dc075483229a079f329f4e36b1